### PR TITLE
Until there is a feedburner account, use atom.xml

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,6 +60,8 @@
     <link rel="stylesheet" href="/css/responsive.css" />
     {% if site.feedburner %}
     <link href="http://feeds.feedburner.com/{{ site.feedburner.id }}" rel="alternate" title="{{ site.title }}" type="application/atom+xml" />
+    {% else %}
+    <link href="/atom.xml" rel="alternate" title="{{ site.title }}" type="application/atom+xml" />
     {% endif %}
     {% if site.google_analytics %}
     <!-- google analytics async -->


### PR DESCRIPTION
If there is no feedburner account in the _config.yml, use the standard atom.xml for <head>'s rss <link>
