### PR TITLE
Subscription link and other link fixes in the footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -116,6 +116,7 @@
             <h5>Colophon</h5>
             <p>&copy;2013 SimpleA11Y<br/>
               Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a> &amp; <a href="http://twitter.github.com/bootstrap/">Bootstrap</a></p>
+            <p><a href="/atom.xml">Subscribe</a></p>
           </div>
 
         </div>


### PR DESCRIPTION
Fixes #6. I decided not to pull in fontawesome since it'd be silly to add 30KB for a single feed icon.
