### PR TITLE
Added Quick Tip for ARIA Landmark Roles

### DIFF
--- a/_posts/2013-01-14-aria-landmark-roles.md
+++ b/_posts/2013-01-14-aria-landmark-roles.md
@@ -13,7 +13,7 @@ categories:
 * **banner** – Typically the “header” of your page that includes the name of the site
 * **search** – For the search form
 * **main** – This would designate the main content area on your site
-* **navigation** – Use on any navigation list
+* **navigation** – Use on any navigation list, typically on the nav element
 * **contentinfo** – contains information about the parent document such as copyrights and links to privacy statements
 
 To add a role to an element, simply add the "role" as an attribute:


### PR DESCRIPTION
You had "Basic ARIA roles" under Concepts but it seemed to fit under Quick Tips better. Let me know if you'd prefer it moved and I'll do so.
