### PR TITLE
Updates to checklist

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -170,9 +170,9 @@ title: Checklist
                 <input name="test-colorcontrast" id="test-colorcontrast" type="checkbox">
               </label>
 
-              <p>Best done early in the process, by ensuring that the foreground and background colors of your site have sufficiant contrast you will help make your site more readable for everyone. <a href="http://www.dasplankton.de/ContrastA/">Contrast A</a> or <a href="http://leaverou.github.com/contrast-ratio/">Contrast Ratio</a> are tools for checking the contrast of your colors for both standard vision and color deficient user.</p>
+              <p>Best done early in the process, by ensuring that the foreground and background colors of your site have sufficiant contrast you will help make your site more readable for everyone. <a href="http://www.dasplankton.de/ContrastA/">Contrast A</a> or <a href="http://leaverou.github.com/contrast-ratio/">Contrast Ratio</a> are tools for checking the contrast of your colors for both standard vision and color deficient users.</p>
 
-              <p>Test against different types of color blindness with a too like <a href="http://colorfilter.wickline.org/">http://colorfilter.wickline.org/</a>.</p>
+              <p>Test against different types of color blindness with a tool like <a href="http://colorfilter.wickline.org/">http://colorfilter.wickline.org/</a>.</p>
 
               <label for="deuteranopia" class="checkbox">Deuteranopia
                 <input name="deuteranopia" id="deuteranopia" type="checkbox">


### PR DESCRIPTION
Removes widget section of checklist because we were recommending that people use `role=application` on the body tag when this is not advisable - https://dvcs.w3.org/hg/aria-unofficial/raw-file/tip/index.html#application 

Moved color blindness to its own section and broke it down by different types
