### PR TITLE
Fix for layout bug on Checklist page under Testing (second checkbox)

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -182,7 +182,7 @@ title: Checklist
 
               <p>Navigating your site using a screen reader will help you see how the blind will experience it.</p>
 
-              <label for="test-colorblindness" class="checkbbx">Test against various types of colorblindness
+              <label for="test-colorblindness" class="checkbox">Test against various types of colorblindness
                 <input name="test-colorblindness" id="test-colorblindess" type="checkbox">
               </label>
 


### PR DESCRIPTION
Corrected `checkbbx` to `checkbox` in class name of colorblindness label to fix layout bug caused by that.
