### PR TITLE
Add fallback background-color for .masthead

### DIFF
--- a/_sass/_jumbotron.scss
+++ b/_sass/_jumbotron.scss
@@ -25,7 +25,7 @@ h3 code {
   color: #fff;
   text-align: left;
   text-shadow: 0 1px 3px rgba(0,0,0,.4), 0 0 30px rgba(0,0,0,.075);
-
+  background-color: #1A274E;
   @include background-image(linear-gradient(bottom left, #1A274E, #397C9C 110%));
 
   -webkit-box-shadow: inset 0 3px 7px rgba(0,0,0,.2), inset 0 -3px 7px rgba(0,0,0,.2);


### PR DESCRIPTION
In IE9, .masthead was displaying as blank. The background was only styled with gradients. I've added a fallback background color for those browsers that don't support gradients. I chose the darkest of the gradient colors used as it has the highest contrast rating for any size text (http://leaverou.github.com/contrast-ratio/#%23fff-on-%231a274e).
