### PR TITLE
Adding resource for online tools

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -96,5 +96,6 @@ description: Accessibility software, books, blogs, online tools, and more
         <li><a href="http://colorfilter.wickline.org/" rel="external">Colorblind Web Page Filter</a></li>
         <li><a href="http://leaverou.github.com/contrast-ratio" rel="external">Contrast Ratio</a> by Lea Verou</li>
         <li><a href="http://www.dasplankton.de/ContrastA/" rel="external">Contrast-A Accessible color combinations tool</a></li>
+        <li><a href="http://squizlabs.github.com/HTML_CodeSniffer/" rel="external">A client-side script that checks HTML source code and detects violations of a defined coding standard</a></li>
     </div>
 </div>


### PR DESCRIPTION
I'd like to add http://squizlabs.github.com/HTML_CodeSniffer/ as a resource for the 'online tools' section on the resources page. It's a handy bookmarklet that examines your code to ensure compliancy and I think it'd be a great resource for devs.
