### PR TITLE
XML-escape the title element in atom.xml

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -16,7 +16,7 @@ layout: nil
 
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="http://{{ site.domain }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>http://{{ site.domain }}{{ post.id }}</id>


### PR DESCRIPTION
The content for the `<title>` element should be escaped in order to prevent an invalid XML document when in cases where the contains an ampersand (&) or less-than (<) characters.

This fixes issue #154
