### PR TITLE
Enhancement: Removing skip nav link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,6 @@
     {% endif %}
   </head>
   <body>
-    <a href="#content" class="visuallyhidden">Skip Navigation</a>
     <nav role="navigation" class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container-fluid">
@@ -51,7 +50,7 @@
       </div>
     </nav>
 
-    <main role="main" id="content">
+    <main role="main">
     {{ content }}
     </main>
 


### PR DESCRIPTION
We already have appropriate landmark roles, thus making the skip nav link unnecessary. Prior to aria landmarks, this seems to be a sure thing for accessibility, but not so much now.  Good thing I just pushed that up last night :)
