### PR TITLE
Spelling error (strucure > structure)

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -88,7 +88,7 @@ description: A beginner's guide to web accessibility
 				<fieldset id="forms">
 					<legend>Document Outline</legend>
 					<!-- form document-outline -->
-					<label for="document-outline" class="checkbox">Use semantic headings and strucure
+					<label for="document-outline" class="checkbox">Use semantic headings and structure
 						<input name="document-outline" type="checkbox" id="document-outline">
 					</label>
 				</fieldset>


### PR DESCRIPTION
Corrected spelling error. "strucure" should be "structure".
