### PR TITLE
Clean up article title and codeblocks

### DIFF
--- a/_posts/2013-02-09-how-to-use-application-role.md
+++ b/_posts/2013-02-09-how-to-use-application-role.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: |
-    How&ndash;to: Use <code>role="application"</code>
+    How&ndash;to: Use role="application"
 description: <strong>NEVER</strong> use <code>role=application</code> on a widely containing element such as <code>&lt;body&gt;</code> if your page consists mostly of traditional widgets or page elements.
 # date:
 # last_updated:
@@ -10,7 +10,7 @@ categories:
   - How-tos
 ---
 
-**NEVER** use ``role="application"`` on a widely containing element such as ``<body>`` if your page consists mostly of traditional widgets or page elements such as links that the user does not have to interact with in focus mode. Using ``role="application"`` unnecessarily can cause huge headaches for any assistive technology user trying to use your site/application. Only put it on the ``<body>`` element if your page consists solely of a widget or set of widgets that all need the focus mode[^focusmode] to be turned on.
+**NEVER** use `role="application"` on a widely containing element such as `<body>` if your page consists mostly of traditional widgets or page elements such as links that the user does not have to interact with in focus mode. Using `role="application"` unnecessarily can cause huge headaches for any assistive technology user trying to use your site/application. Only put it on the `<body>` element if your page consists solely of a widget or set of widgets that all need the focus mode[^focusmode] to be turned on.
 
 **Do**
 


### PR DESCRIPTION
Cleaned up the role=application article title to NOT have a codeblock. Keepin' it simple.
