### PR TITLE
Added legend element to checklist

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -152,7 +152,7 @@ description: A beginner's guide to web accessibility
 					<p>(e.g. <code class="language-markup">&lt;label for="name"&gt;Name:&lt;/label&gt;&lt;input id="name" type="text"&gt;</code>)</p>
 
 					<!-- fieldset -->
-					<label for="group-related-elements" class="checkbox">Group related form elements with <code class="language-markup">fieldset</code>
+					<label for="group-related-elements" class="checkbox">Group related form elements with <code class="language-markup">fieldset</code> and describe the group with <code class="language-markup">legend</code>
 						<input name="group-related-elements" type="checkbox" id="group-related-elements">
 					</label>
 


### PR DESCRIPTION
The legend explains to screen-readers what the group of fields is about. Especially important for groups of checkboxes or radio buttons, as the legend will be the question that the checkboxes or radio buttons are answers for. "The first element inside the fieldset must be a legend element, which provides a label or description for the group" - http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H71
