### PR TITLE
Changed main area from section to div

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -49,7 +49,7 @@ description: A beginner's guide to web accessibility
 					<p>Contains navigational links.</p>
 
 					<!-- main -->
-					<label for="main-role" class="checkbox"><code>&lt;section role="main"&gt;</code>
+					<label for="main-role" class="checkbox"><code>&lt;div role="main"&gt;</code>
 						<input name="aria-main-role" id="main-role" type="checkbox">
 					</label>
 


### PR DESCRIPTION
Hi, what do people think about changing the recommendation for the main content area to be a div instead of a section?

Bruce Lawson talks about this exact thing at http://html5doctor.com/the-section-element/

> "What we’ve been doing wrong is using section to ... demarcate the main content area from the nav, header, footer etc. These are jobs for div, not section."
