### PR TITLE
update references to Bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We have a list of articles we'd love to see written. Have an idea for an article
 Here are some suggestions and tips on writing your article:
 
 - Short - Aim for a timed reading length of approximately two minutes.
-- Focused - Keep it digestable and to a single topic. Articles that span multiple areas and topics are better broken up.
+- Focused - Keep it digestible and to a single topic. Articles that span multiple areas and topics are better broken up.
 
 ## Reporting issues
 Notice something inaccurate? Noticed something inaccessible on this site? You think you can code something up better?
@@ -49,4 +49,4 @@ If you have a feature request(s) we suggest filing an issue initially to discuss
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the [APLv2](https://github.com/twitter/bootstrap/blob/master/LICENSE).
+By contributing your code, you agree to license your contribution under the terms of the [APLv2](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This site is the product of a community of people who want to help to make web a
 
 ##Requirements
 ========
-In order to contribute to the website&rsquo;s codebase, you&rsquo;ll need to know a bit about [Jekyll](https://github.com/mojombo/jekyll), [Compass](http://compass-style.org), [Sass](http://sass-lang.com), [Twitter Bootstrap](http://twitter.github.com/bootstrap), [Bash](http://www.gnu.org/software/bash/manual/bashref.html#What-is-Bash_003f) and [Markdown](http://daringfireball.net/projects/markdown/). You'll also need to know how to install *[Ruby Gems](https://rvm.io)* and of course have *[Ruby](http://www.ruby-lang.org/en/downloads/)* installed on your machine.
+In order to contribute to the website&rsquo;s codebase, you&rsquo;ll need to know a bit about [Jekyll](https://github.com/mojombo/jekyll), [Compass](http://compass-style.org), [Sass](http://sass-lang.com), [Bootstrap](http://getbootstrap.com), [Bash](http://www.gnu.org/software/bash/manual/bashref.html#What-is-Bash_003f) and [Markdown](http://daringfireball.net/projects/markdown/). You'll also need to know how to install *[Ruby Gems](https://rvm.io)* and of course have *[Ruby](http://www.ruby-lang.org/en/downloads/)* installed on your machine.
 
 ###Gems Installation
 
@@ -37,7 +37,7 @@ Authored with [Compass](http://compass-style.org) and [Sass](http://sass-lang.co
 
 ###Framework
 
-The site is built on a customized [Compass](http://compass-style.org/) port of [Twitter Bootstrap](http://twitter.github.com/bootstrap). [Jekyll](https://github.com/mojombo/jekyll) is used for templating and posts.
+The site is built on a customized [Compass](http://compass-style.org/) port of [Bootstrap](http://getbootstrap.com). [Jekyll](https://github.com/mojombo/jekyll) is used for templating and posts.
 
 ##Local Development
 ========

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,7 +69,7 @@
           <div class="span4">
             <h5>Colophon</h5>
             <p>&copy; <span class="a11y-copyright"></span> The Accessibility Project<br />
-              Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a> &amp; <a href="http://twitter.github.com/bootstrap/">Bootstrap</a></p>
+              Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a> &amp; <a href="http://getbootstrap.com">Bootstrap</a></p>
             <p><a href="https://twitter.com/A11YProject">@A11YProject</a> | <a href="/atom.xml">Subscribe</a></p>
             <div id="google_translate_element"></div>
 

--- a/about.md
+++ b/about.md
@@ -8,7 +8,7 @@ For many web developers, accessibility is complex and somewhat difficult. The Ac
 
 1. **Digestible.** We strive to feature short, digestible pieces of content.
 1. **Up-to-date.** The project is hosted on Github so information can be current with the latest standards.
-1. **Forgiving.** People make mistakes and web accessiblity is hard, so we seek to be encouraging.
+1. **Forgiving.** People make mistakes and web accessibility is hard, so we seek to be encouraging.
 
 ### Why accessibility is important
 
@@ -20,4 +20,4 @@ If you care and are knowledgeable about accessibility and want to help please co
 
 ### About this site
 
-This site is built with [Jekyll](https://github.com/mojombo/jekyll) &amp; [Bootstrap](http://twitter.github.com/bootstrap/), collaboratively by developers (see the footer) on [Github](https://github.com/a11yproject/a11yproject.com/). In its current state, The Accessibility Project may not be a perfect example of an accessible website&hellip; yet. We're commited, through the power of Open Source, to incrementally improve our own accessibility on the site going forward.
+This site is built with [Jekyll](https://github.com/mojombo/jekyll) &amp; [Bootstrap](http://getbootstrap.com), collaboratively by developers (see the footer) on [Github](https://github.com/a11yproject/a11yproject.com/). In its current state, The Accessibility Project may not be a perfect example of an accessible website&hellip; yet. We're committed, through the power of Open Source, to incrementally improve our own accessibility on the site going forward.


### PR DESCRIPTION
Bootstrap is no longer organizationally affiliated with Twitter.
Bootstrap's website URLs have changed.
Also fixes some typos I came across.
