### PR TITLE
Correct links under Further Reading (404 error fix + naming and accreditation + accessibility consideration) 

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -68,8 +68,8 @@ description: Accessibility software, books, blogs, online tools, and more
         <ul>
             <li><a href="http://webaim.org/resources/designers/">Web Accessibility for Designers</a> [Infographic]</li>
             <li><a href="http://vimeo.com/1157346">Aaron Cannon, Blind Web Developer</a> [Video]</li>
-            <li><a href="http://northtemple.com/1608" rel="external">Accessibility Checklist</a> by Aaron Cannon</li>
-            <li><a href="http://cameronmoll.com/downloads/Web_Accessibility_Checklist.pdf" rel="external">PDF Checklist</a> by Cameron Moll</li>
+            <li><a href="http://cameronmoll.com/archives/2008/06/web_accessibility_checklist/" rel="external" title="Accessibility Checklist Article by Cameron Moll [external link]">Accessibility Checklist Article</a> by Cameron Moll</li>
+            <li><a href="http://cameronmoll.com/downloads/Web_Accessibility_Checklist.pdf" rel="external" title="Accessibility Checklist PDF by Aaron Cannon [external link]">Accessibility Checklist PDF</a> by Aaron Cannon</li>
             <li><a href="http://www.apple.com/accessibility" rel="external">Apple’s Commitment to Accessibility</a></li>
             <li><a href="http://diveintoaccessibility.info/table_of_contents.html" rel="external">Dive Into Accessibility: 30 days to a more accessible web site</a></li></li>
             <li><a href="http://wearecolorblind.com" rel="external">We are Color Blind</a> by Tom van Beveren</li>


### PR DESCRIPTION
- (404 error fix) http://northtemple.com/1608 doesn't exist, so I have repointed to where the file is hosted (http://cameronmoll.com/downloads/Web_Accessibility_Checklist.pdf). 
- (Naming and accreditation) Gave correct accreditation to Cameron Moll's article discussing Aaron Cannon's PDF checklist. 
- (Accessibility consideration) Also added title attributes to the two anchor tags referenced <3
