### PR TITLE
Link to the github project

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,7 +82,7 @@
     </footer>
 
   {% if site.github %}
-    <a href="http://github.com/{{ site.github.username }}"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/a11yproject/a11yproject.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
   {% endif %}
 
     <!-- Le javascript


### PR DESCRIPTION
The link "Fork Me on Github" was linking to github.com instead of https://github.com/a11yproject/a11yproject.com

Rather than setting the _config for `site.github.username`, just modify the template.  Setting the username would not link to the specific project, but rather https://github.com/a11yproject/

Another option is to set `site.github.username` to `a11yproject/a11yproject.com`, which seems weird because that isn't a "username".
