### PR TITLE
removing role="form" from checklist

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -28,7 +28,7 @@ description: A beginner's guide to web accessibility
 		</style>
 
 		<div class="row-fluid">
-			<form action="/" data-persist="garlic" method="POST" class="checklist" id="simple-a11y-checklist" role="form">
+			<form action="/" data-persist="garlic" method="POST" class="checklist" id="simple-a11y-checklist">
 
 				<!-- Aria Roles -->
 				<fieldset id="aria-roles">
@@ -68,13 +68,6 @@ description: A beginner's guide to web accessibility
 					</label>
 
 					<p>Supporting section related to the main content even when separated.</p>
-
-					<!-- form -->
-					<label for="form-role" class="checkbox"><code>&lt;form role="form"&gt;</code>
-						<input name="aria-contentinfo-role" id="form-role" type="checkbox">
-					</label>
-
-					<p>A region that contains a collection of items and objects that, as a whole, combine to create a form.</p>
 
 					<!-- contentinfo -->
 					<label for="content-info" class="checkbox"><code>&lt;footer role="contentinfo"&gt;</code>


### PR DESCRIPTION
This isn't necessary and conflicts with the "Getting started with ARIA" article. Closes #272
