### PR TITLE
Feature/footer localstorage

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -31,202 +31,213 @@ $(document).ready(function(){
               localStorage.setItem("pageLoads", parseInt(localStorage.getItem('pageLoads')) + 1);
             }
 
-            console.log(localStorage.getItem("pageLoads"));
+            // console.log(localStorage.getItem("pageLoads"));
 
-          function _listContributors(data) {
-            $contributorsOutput.html("");
-            var html = '';
-            $(data).each(function(i, user){
-              html += '<li><a href="'+ user.url.replace('api.','').replace('users/','') +'"><img src="'+ user.avatar_url +'" alt="'+ user.login +'" class="contributor-avatar"></a></li>';
-            });
-            $contributorsOutput.html(html);
-            localStorage.setItem("contribsHtml",html);
-            localStorage.setItem("contribsLoaded",true);
-          }
-
-          function _listContributorsLocalStorage(){
-            console.log("loading contribs from local storage");
-            $contributorsOutput.html(localStorage.getItem("contribsHtml"));
-          }
-
-          function _contribPagination(meta){
-            var
-              link = meta.Link,
-              $output = $paginationOutput;
-              $output.html("");
-
-              $(link).each(function(i,item){
-                var text = item[1].rel,
-                    url = item[0],
-                    html = "<li><a href="+url+" class='"+paginationClass+"'>"+text+"</a></li>";
-                    $output.append(html);
+            function _listContributors(data) {
+              $contributorsOutput.html("");
+              var html = '';
+              $(data).each(function(i, user){
+                html += '<li><a href="'+ user.url.replace('api.','').replace('users/','') +'"><img src="'+ user.avatar_url +'" alt="'+ user.login +'" class="contributor-avatar"></a></li>';
               });
+              $contributorsOutput.html(html);
+              localStorage.setItem("contribsHtml",html);
+              localStorage.setItem("contribsLoaded",true);
+            }
 
-              _simplifyPager(); // cut down pager
-          }
+            function _listContributorsLocalStorage(){
+              // console.log("loading contribs from local storage");
+              $contributorsOutput.html(localStorage.getItem("contribsHtml"));
+            }
 
-          function _contribPaginationLocalStorage(){
-            console.log("loading pagination from");
-            $paginationOutput.html(localStorage.getItem("contribsPagination"));
-          }
+            function _contribPagination(meta){
+              var
+                link = meta.Link,
+                $output = $paginationOutput;
+                $output.html("");
 
-          function _paginationTriggers(){
-            $("."+paginationClass).click(function(e){
-              e.preventDefault();
-              localStorage.removeItem("contribsLoaded");
-              var url = $(this).attr("href");
-              _getContributors(url);
-            });
-          }
+                $(link).each(function(i,item){
+                  var text = item[1].rel,
+                      url = item[0],
+                      html = "<li><a href="+url+" class='"+paginationClass+"'>"+text+"</a></li>";
+                      $output.append(html);
+                });
 
-          function _getContributors(apiUrl){
+                _simplifyPager(); // cut down pager
+            }
 
-            if(localStorage.getItem("contribsLoaded") && localStorage.getItem("pageLoads") <= 20){
-              _listContributorsLocalStorage(); // output contribs from localStorage
-              _contribPaginationLocalStorage(); // output contrib pagination from localStorage
-              _paginationTriggers(); // handle pagination clicks
-            }else{
-              console.log("loading from API");
-              localStorage.removeItem("pageLoads");
-              $.ajax({
-                type: 'GET',
-                url: apiUrl,
-                async: false,
-                contentType: "application/json",
-                dataType: 'jsonp',
-                success: function(data){
-                  if(data.meta.status != "200"){
-                    _throwError(data.meta);
-                  }else{
-                    _listContributors(data.data); // output contribs
-                    _contribPagination(data.meta); // draw pagination
-                    _paginationTriggers(); // handle pagination clicks
+            function _contribPaginationLocalStorage(){
+              // console.log("loading pagination from");
+              $paginationOutput.html(localStorage.getItem("contribsPagination"));
+            }
+
+            function _paginationTriggers(){
+              $("."+paginationClass).click(function(e){
+                e.preventDefault();
+                localStorage.removeItem("contribsLoaded");
+                var url = $(this).attr("href");
+                _getContributors(url);
+              });
+            }
+
+            function _getContributors(apiUrl){
+
+              if(localStorage.getItem("contribsLoaded") && localStorage.getItem("pageLoads") <= 20){
+                _listContributorsLocalStorage(); // output contribs from localStorage
+                _contribPaginationLocalStorage(); // output contrib pagination from localStorage
+                _paginationTriggers(); // handle pagination clicks
+              }else{
+                // console.log("loading from API");
+                localStorage.removeItem("pageLoads");
+                $.ajax({
+                  type: 'GET',
+                  url: apiUrl,
+                  async: false,
+                  contentType: "application/json",
+                  dataType: 'jsonp',
+                  success: function(data){
+                    if(data.meta.status != "200"){
+                      _throwError(data.meta);
+                    }else{
+                      _listContributors(data.data); // output contribs
+                      _contribPagination(data.meta); // draw pagination
+                      _paginationTriggers(); // handle pagination clicks
+                    }
+                  },
+                  error: function(e) {
+                    // console.log(e.message);
                   }
-                },
-                error: function(e) {
-                  console.log(e.message);
-                }
-              });
-            }
-          }
-
-          function _throwError(data){
-            $contributorsOutput.text("Error");
-            console.log(data);
-          }
-
-          function _simplifyPager(){
-            $pager.find("li").each(function(){
-              var $itemText = $(this).find("a").text();
-              // hide unwanted pagination items
-              // replace default text next/prev
-              switch($itemText) {
-                case "first":
-                  $(this).hide();
-                  break;
-                case "last":
-                  $(this).hide();
-                  break;
-                case "next":
-                  $(this).find("a").text("Next");
-                  break;
-                case "prev":
-                  $(this).find("a").text("Previous");
-                  break;
-                default:
+                });
               }
-            });
-
-            localStorage.setItem("contribsPagination",$pager.html())
-
-          }
-
-          // get contributors on landing
-          if(window.matchMedia('(min-width: 480px)').matches) {
-            _getContributors(baseUrl);
-          }
-
-        }
-
-        function gitHubStats(){
-
-          var
-            $parent = $(".github-data"),
-            $dataContributors = $parent.find(".data.contributors"),
-            $dataStars = $parent.find(".data.stars"),
-            $dataOpenIssues = $parent.find(".data.open-issues"),
-            baseUrl = "https://api.github.com/repos/a11yproject/a11yproject.com",
-            contribUrl = baseUrl+"/contributors?per_page=5000&callback=?",
-            starsUrl = baseUrl,
-            openIssuesUrl = baseUrl;
-
-            function _outputData(target,data){
-              $(target).text(data);
             }
 
-            // contributors
-            function _grabContributors(url){
-              $.ajax({
-                type: "GET",
-                url: url,
-                async: true,
-                contentType: "application/json",
-                dataType: "jsonp",
-                success: function(data){
-                  var data = data.data;
-                 _outputData($dataContributors,data.length);
-                },
-                error: function(e) {
-                  console.log(e.message);
+            function _throwError(data){
+              $contributorsOutput.text("Error Loading Contributors...");
+              // console.log(data);
+            }
+
+            function _simplifyPager(){
+              $pager.find("li").each(function(){
+                var $itemText = $(this).find("a").text();
+                // hide unwanted pagination items
+                // replace default text next/prev
+                switch($itemText) {
+                  case "first":
+                    $(this).hide();
+                    break;
+                  case "last":
+                    $(this).hide();
+                    break;
+                  case "next":
+                    $(this).find("a").text("Next");
+                    break;
+                  case "prev":
+                    $(this).find("a").text("Previous");
+                    break;
+                  default:
                 }
               });
-            } // _grabContributors()
 
-            //  stars
-            function _grabStars(url){
-              $.ajax({
-                type: "GET",
-                url: url,
-                async: true,
-                contentType: "application/json",
-                dataType: "jsonp",
-                success: function(data){
-                  var data = data.data;
-                  _outputData($dataStars,data.stargazers_count);
-                },
-                error: function(e) {
-                  console.log(e.message);
+              localStorage.setItem("contribsPagination",$pager.html())
+
+            }
+
+            // get contributors on landing
+            if(window.matchMedia('(min-width: 480px)').matches) {
+              _getContributors(baseUrl);
+            }
+
+          }
+
+          function gitHubStats(){
+
+            var
+              $parent = $(".github-data"),
+              $dataContributors = $parent.find(".data.contributors"),
+              $dataStars = $parent.find(".data.stars"),
+              $dataOpenIssues = $parent.find(".data.open-issues"),
+              baseUrl = "https://api.github.com/repos/a11yproject/a11yproject.com",
+              contribUrl = baseUrl+"/contributors?per_page=5000&callback=?",
+              starsUrl = baseUrl,
+              openIssuesUrl = baseUrl;
+
+              function _outputData(target,data,localStorageVar){
+                $(target).text(data);
+                if(localStorageVar){
+                  localStorage.setItem(localStorageVar,data);
                 }
-              });
-            } // _grabStars()
+              }
 
-            //  open issues
-            function _grabOpenIssues(url){
-              $.ajax({
-                type: "GET",
-                url: url,
-                async: true,
-                contentType: "application/json",
-                dataType: "jsonp",
-                success: function(data){
-                  var data = data.data;
-                  _outputData($dataOpenIssues,data.open_issues_count);
-                },
-                error: function(e) {
-                  console.log(e.message);
-                }
-              });
-            } // _grabOpenIssues()
+              // contributors count
+              function _grabContributors(url){
+                $.ajax({
+                  type: "GET",
+                  url: url,
+                  async: true,
+                  contentType: "application/json",
+                  dataType: "jsonp",
+                  success: function(data){
+                    var data = data.data;
+                   _outputData($dataContributors,data.length,"contribStat");
+                  },
+                  error: function(e) {
+                    console.log(e.message);
+                  }
+                });
+              } // _grabContributors()
 
-            // init
-            _grabContributors(contribUrl);
-            _grabStars(starsUrl);
-            _grabOpenIssues(openIssuesUrl);
+              //  stars count
+              function _grabStars(url){
+                $.ajax({
+                  type: "GET",
+                  url: url,
+                  async: true,
+                  contentType: "application/json",
+                  dataType: "jsonp",
+                  success: function(data){
+                    var data = data.data;
+                    _outputData($dataStars,data.stargazers_count,"starStat");
+                  },
+                  error: function(e) {
+                    console.log(e.message);
+                  }
+                });
+              } // _grabStars()
 
-        } // gitHubStats
+              //  open issues count
+              function _grabOpenIssues(url){
+                $.ajax({
+                  type: "GET",
+                  url: url,
+                  async: true,
+                  contentType: "application/json",
+                  dataType: "jsonp",
+                  success: function(data){
+                    var data = data.data;
+                    _outputData($dataOpenIssues,data.open_issues_count,"openIssueStat");
+                  },
+                  error: function(e) {
+                    console.log(e.message);
+                  }
+                });
+              } // _grabOpenIssues()
 
-        gitHubContributors();
-        gitHubStats();
+              // init
+              if(localStorage.getItem("contribsLoaded") && localStorage.getItem("pageLoads") <= 20){
+                // localStorage
+                // console.log('firing stats from local storage');
+                _outputData($dataContributors,localStorage.getItem("contribStat"));
+                _outputData($dataStars,localStorage.getItem("starStat"));
+                _outputData($dataOpenIssues,localStorage.getItem("openIssueStat"));
+              }else{
+                _grabContributors(contribUrl);
+                _grabStars(starsUrl);
+                _grabOpenIssues(openIssuesUrl);
+              }
+
+          } // gitHubStats
+
+          gitHubContributors();
+          gitHubStats();
 
       }, // footerContributors
 


### PR DESCRIPTION
Howdy! I've hacked the footer JS a bit to load contributors and GH stats via localStorage in an effort to reduce the individual IP 60 per hour API rate limit. 

Here is how it works.
1. User lands on page and page load variable is incremented.
2. Contributors and Stats are stored into localStorage.
3. User reloads/visits another page and if localStorage has contributors set then we load them from there and not the API
4. We load from local storage every 20 page loads.
5. If user interacts with pagination it pings the API.. no biggie
5. After 20 page loads (from localStorage) we ping the API again and it all starts over. 

This approach affords the user many more page views and keeps the data fairly accurate. This data doesn't need to be 'down-to-the-second' accurate so I felt we could push some of the lifting to localStorage to help cut down on user rate limits enforced by GitHub.

This should give each user over a 1000 page views per hour which should do the trick :)

Let me know what you think.
