### PR TITLE
WAVE Toolbar Extension (Firefox and Chrome)

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -10,7 +10,8 @@ description: Accessibility software, books, blogs, online tools, and more
         <ul>
             <li><a href="http://www.paciellogroup.com/resources/contrastAnalyser" rel="external">Colour Contrast Analyser</a> (Mac/Win)</li>
             <li><a href="http://colororacle.org/" rel="external">Color Oracle</a> (Mac/Win)</li>
-            <li><a href="http://wave.webaim.org/" rel="external">WAVE</a> (Firefox Extension)</li>
+            <li><a href="https://addons.mozilla.org/en-US/firefox/addon/wave-toolbar/" rel="external">WAVE Toolbar</a> (Firefox Extension)</li>
+            <li><a href="https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh" rel="external">WAVE Toolbar</a> (Chrome Extension)</li>
             <li><a href="http://www.paciellogroup.com/resources/wat/ie" rel="external">WAT</a> (IE/<a href="http://www.paciellogroup.com/resources/wat/opera" rel="external">Opera</a>)</li>
             <li><a href="https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en" rel="external">Chrome Accessibility Tools</a> (Chrome Mac/Win)</li>
         </ul>


### PR DESCRIPTION
Fixed the link for the Firefox extension. It was linked to the online tool and that link is already listed under "Online Tools".

Also, added the Chrome extension that was released earlier this week.
