### PR TITLE
Removing broken link from Resources

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -38,7 +38,6 @@ description: Accessibility software, books, blogs, online tools, and more
             <li><a href="http://www.w3.org/WAI/PF/aria-practices/" rel="external">W3C: Recommended ARIA usage by feature</a></li>
             <li><a href="http://rawgithub.com/w3c/aria-in-html/master/index.html" rel="external">W3C: Using ARIA with HTML</a></li>
             <li><a href="http://www.w3.org/WAI/tutorials/" rel="external">W3C: Web Accessibility Tutorials</a></li>
-            <li><a href="http://test.cita.illinois.edu/aria/" rel="external">Illinois Center for Information Technology and Web Accessibility WAI-ARIA Examples</a></li>
             <li><a href="http://www.html5accessibility.com/" rel="external">HTML5 Accessibility</a></li>
             <li><a href="http://paypal.github.io/bootstrap-accessibility-plugin/" rel="external">Bootstrap accessibility plugin</a></li>
             <li><a href="http://dylanb.github.io/periodic-aria-roles.html" rel="external">Periodic Table of ARIA roles</a></li>


### PR DESCRIPTION
Illinois Center for Information Technology aria examples page is broken. There isn't an obvious contact to ask them to fix. This site has a date of 2008 on it, so I wouldn't think linking to the [main page](http://test.cita.uiuc.edu/index.php) would be a great option, especially if that page has the same broken link on it. 

fixes #346 