### PR TITLE
added What Input? to the list of scripts to remove outlines

### DIFF
--- a/_posts/2013-01-25-never-remove-css-outlines.md
+++ b/_posts/2013-01-25-never-remove-css-outlines.md
@@ -21,6 +21,8 @@ If you do not like the default focus outline that is displayed when a user click
     * [outliner.js](https://gist.github.com/2470777), a cross-lib implementation with event delegation, by [Aireh Glazer](https://twitter.com/#!/arglazer)
 
     * [outline.js](https://github.com/lindsayevans/outline.js), a similar approach that uses `mousedown` instead of `mouseover`, by [Lindsay Evans](http://twitter.com/lindsayevans/)
+    
+    * [What Input?](https://github.com/ten1seven/what-input), differently from the previous two, adds an attribute to your `body` allowing you to write CSS that will be enabled only if the user is using the keyboard to navigate.
 
     Consider this third solution as a last resort. Some browser/screen reader combinations fire mouse events, which could cause outlines to disappear while using this method.
 


### PR DESCRIPTION
I think "What Input?" is the best solution if a front-end developer needs to remove outlines from the elements of the page.

It allows you to style your elements in a specific manner only if the user is using a specific input method (mouse, touch, keyboard) and does not interfere with the click events.
Additionally, it's much more lightweight.

In the startup I work for we used it successfully and now most of the app is keyboard accessible.