### PR TITLE
Reordered links alphabetically

### DIFF
--- a/patterns/index.html
+++ b/patterns/index.html
@@ -28,9 +28,9 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Accordions &amp; Tabs</h3>
         <ul>
+            <li><a href="http://codepen.io/mpiotrowicz/pen/gocmu" rel="external">Responsive Tabs to Accordion</a></li>
             <li><a href="http://codepen.io/svinkle/pen/mKfru">Simple Accordion</a></li>
             <li><a href="http://codepen.io/svinkle/pen/edmDF">Simple Tabs</a></li>
-            <li><a href="http://codepen.io/mpiotrowicz/pen/gocmu" rel="external">Responsive Tabs to Accordion</a></li>
         </ul>
     </div>
 </div>
@@ -47,7 +47,7 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Anchors/Links</h3>
         <ul>
-            <li>Read More:
+            <li>"Read More":
                 <ul>
                     <li><a href="http://codepen.io/svinkle/pen/Jmlbw">hidden &lt;span&gt;</a>
                     <li><a href="http://codepen.io/grayghostvisuals/pen/Gtoua">aria-labelledby</a></li>
@@ -60,8 +60,8 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Modal Windows</h3>
         <ul>
+            <li><a href="http://codepen.io/scottohara/pen/lIdfv" rel="external">An Accessible Modal Window with JavaScript &amp; CSS</a></li>
             <li><a href="http://accessibility.oit.ncsu.edu/training/aria/modal-window/version-3/" rel="external">The Incredible Accessible Modal Window, Version 3</a></li>
-            <li><a href="http://codepen.io/scottohara/pen/lIdfv" rel="external">An accessible Modal Window with JavaScript & CSS</a></li>
         </ul>
     </div>
 </div>

--- a/patterns/index.html
+++ b/patterns/index.html
@@ -11,17 +11,17 @@ description: An accessible widget & pattern library
         <h3>Menus</h3>
         <ul>
             <li><a href="http://codepen.io/grayghostvisuals/pen/d7d131e58a33665d24ea0881c01a02b8" rel="external">Dropdown</a></li>
-            <li><a href="http://adobe-accessibility.github.io/Accessible-Mega-Menu">Mega Dropdown</a></li>
-            <li><a href="http://codepen.io/svinkle/pen/LDKwA">Mobile Toggle</a></li>
-            <li><a href="http://codepen.io/grayghostvisuals/pen/IkmGF">Off Canvas Push</a></li>
+            <li><a href="http://adobe-accessibility.github.io/Accessible-Mega-Menu" rel="external">Mega Dropdown</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/LDKwA" rel="external">Mobile Toggle</a></li>
+            <li><a href="http://codepen.io/grayghostvisuals/pen/IkmGF" rel="external">Off Canvas Push</a></li>
         </ul>
     </div>
 
     <div class="span4">
         <h3>Imagery</h3>
         <ul>
-            <li><a href="http://codepen.io/grayghostvisuals/pen/eyvrK">SVG</a></li>
-            <li><a href="http://codepen.io/mpiotrowicz/pen/yndxA">Video Element Backgrounds</a></li>
+            <li><a href="http://codepen.io/grayghostvisuals/pen/eyvrK" rel="external">SVG</a></li>
+            <li><a href="http://codepen.io/mpiotrowicz/pen/yndxA" rel="external">Video Element Backgrounds</a></li>
         </ul>
     </div>
 
@@ -29,8 +29,8 @@ description: An accessible widget & pattern library
         <h3>Accordions &amp; Tabs</h3>
         <ul>
             <li><a href="http://codepen.io/mpiotrowicz/pen/gocmu" rel="external">Responsive Tabs to Accordion</a></li>
-            <li><a href="http://codepen.io/svinkle/pen/mKfru">Simple Accordion</a></li>
-            <li><a href="http://codepen.io/svinkle/pen/edmDF">Simple Tabs</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/mKfru" rel="external">Simple Accordion</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/edmDF" rel="external">Simple Tabs</a></li>
         </ul>
     </div>
 </div>
@@ -39,8 +39,8 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Buttons</h3>
         <ul>
-            <li><a href="http://codepen.io/grayghostvisuals/pen/HhiAz">Form Submission</a></li>
-            <li><a href="http://codepen.io/svinkle/pen/FHGBh">Single Toggle (anchor)</a></li>
+            <li><a href="http://codepen.io/grayghostvisuals/pen/HhiAz" rel="external">Form Submission</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/FHGBh" rel="external">Single Toggle (anchor)</a></li>
         </ul>
     </div>
 
@@ -49,11 +49,11 @@ description: An accessible widget & pattern library
         <ul>
             <li>"Read More":
                 <ul>
-                    <li><a href="http://codepen.io/svinkle/pen/Jmlbw">hidden &lt;span&gt;</a>
-                    <li><a href="http://codepen.io/grayghostvisuals/pen/Gtoua">aria-labelledby</a></li>
-                    <li><a href="http://codepen.io/joe-watkins/pen/xaDbJ">aria-label</a></li>
+                    <li><a href="http://codepen.io/svinkle/pen/Jmlbw" rel="external">hidden &lt;span&gt;</a>
+                    <li><a href="http://codepen.io/grayghostvisuals/pen/Gtoua" rel="external">aria-labelledby</a></li>
+                    <li><a href="http://codepen.io/joe-watkins/pen/xaDbJ" rel="external">aria-label</a></li>
                 </ul>
-            <li><a href="http://codepen.io/joe-watkins/pen/rjhiK">Skip To Content</a></li>
+            <li><a href="http://codepen.io/joe-watkins/pen/rjhiK" rel="external">Skip To Content</a></li>
         </ul>
     </div>
 
@@ -70,7 +70,7 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Tables</h3>
         <ul>
-            <li><a href="http://codepen.io/svinkle/pen/zmlEi">Simple Data Table</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/zmlEi" rel="external">Simple Data Table</a></li>
         </ul>
     </div>
     <div class="span4">
@@ -83,7 +83,7 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Video Players</h3>
         <ul>
-            <li><a href="http://github.com/paypal/accessible-html5-video-player/">Accessible HTML5 Video Player</a></li>
+            <li><a href="http://github.com/paypal/accessible-html5-video-player/" rel="external">Accessible HTML5 Video Player</a></li>
         </ul>
     </div>
 </div>
@@ -92,14 +92,14 @@ description: An accessible widget & pattern library
     <div class="span4">
         <h3>Labelling</h3>
         <ul>
-            <li><a href="http://codepen.io/svinkle/pen/eNPyEB">Using aria-labelledby with Lists</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/eNPyEB" rel="external">Using aria-labelledby with Lists</a></li>
         </ul>
     </div>
     
     <div class="span4">
         <h3>Other</h3>
         <ul>
-            <li><a href="http://codepen.io/svinkle/pen/yDAiG">Content Touch Target</a></li>
+            <li><a href="http://codepen.io/svinkle/pen/yDAiG" rel="external">Content Touch Target</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
Following the pattern that resources should be listed alphabetically
(https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CONTRIBUTI
NG.md#adding-resources). Also, added quotes (“”) around the Read More
heading to better identify what the section represents. 👍🏼
