### PR TITLE
Skip Nav Post - Adding extra note

### DIFF
--- a/_posts/2013-05-11-skip-nav-links.md
+++ b/_posts/2013-05-11-skip-nav-links.md
@@ -35,7 +35,7 @@ Skip nav links are useful for users who use keyboard navigation only, but screen
 
 **Disclaimer**: The mechanism by which skip navigation links work had for some time been broken in Webkit based browsers and has only [recently been fixed](https://code.google.com/p/chromium/issues/detail?id=37721). Until these browsers release the fixes, you may need to use a javascript polyfill to make skip nav links work.
 
-
 ### Notes
 * Jim Thatcher pioneered skip navigation links [as early as 1998](http://www.jimthatcher.com/skipnavold.htm)
 * An example of a [javascript polyfill by Nicholas C. Zakas](http://www.nczonline.net/blog/2013/01/15/fixing-skip-to-content-links/).
+* An alternative non-Javascript method would be to add tabindex=-1 or 0 to elements that don't normally receive focus. This adds them to the tab order. The bug in Chrome looks to apply to anchors as well. However, the tabindex bypasses the issue. 


### PR DESCRIPTION
The Javascript method isn't necessary if HTML attributes are available to edit. tabindex="-1" or 0 work fine in browsers for maintaining focus and tab order. I didn't want to change the disclaimer and figured an extra note for now should be sufficient.
