### PR TITLE
Add slash at the end in permalinks of posts

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-a11yproject.com
+a11yproject.github.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-a11yproject.github.io
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # standard jekyll configuration
 
-permalink: /posts/:title
+permalink: /posts/:title/
 exclude: ['Rakefile', 'README.md', 'config.rb']
 markdown: kramdown
 


### PR DESCRIPTION
Error 404 in links with slash at the end.
For example: https://github.com/a11yproject/a11yproject.com/blob/gh-pages/checklist.html#L104
Add slash at the end in permalinks of posts to ensure that work well in both cases.

(I edit CNAME but it was an error, sorry)
