### PR TITLE
fix heading markdown code

### DIFF
--- a/_posts/2013-05-15-understanding-vestibular-disorders.md
+++ b/_posts/2013-05-15-understanding-vestibular-disorders.md
@@ -14,19 +14,19 @@ Imagine a world where your internal gyroscope is not working properly. Very simi
 
 Your personal steady-cam is broken and whatever you look at tends to move regardless if you are moving. Let's take that feeling and check out that great new website with animations and parallax scrolling. Does your stomach want to jump out of your throat? Well for many people it does.
 
-##What is it?
+## What is it?
 
 People with vestibular disorders have a problem with their inner ear. It affects their balance as well as their visual perception of their world around them.
 
 Sometimes the sensation lasts only a short while, but others can suffer it for years. Walking becomes a challenge and they have a constant risk of falling. Concentration is diminished leaving the sufferer unfocused and often unproductive. It is often viewed as a "hidden" disability because it has no outward showing symptoms.
 
-##Who is at risk?
+## Who is at risk?
 
 The cause may be from illness, injury, or from a genetic anomaly but anyone can suffer from a vestibular disorder. According to [vestibular.org](http://vestibular.org/understanding-vestibular-disorder), a resource for people with vestibular disorders, as many as 35% of adults aged 40 years or older in the United States have experienced some form of vestibular dysfunction.
 
-##What should you consider?
+## What should you consider?
 
 Don't make animations, sliders, rapid movement start automatically. Give an indicator of what movement will happen on the site when a user takes action. Allow the user the option to turn off any animation and movement.
 
-##Additional Reading
+## Additional Reading
 - [Designing Safer Web Animation For Motion Sensitivity](http://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity)


### PR DESCRIPTION
I've been reading through these - really great content by the way! - and noticed the heading weren't displaying correctly on this page. I think they just need a space after the ```##``` as this is what's on other pages. I've done the simple fix here.

For reference, here's what the page looks like for me before:

![a11y-headings](https://cloud.githubusercontent.com/assets/8886969/18160247/73314396-7024-11e6-8605-426413a0a9ce.png)
