### PR TITLE
Upgrade Jekyll to v3.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "jekyll", "~>3.0.0"
+gem "jekyll", "~>3.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,43 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
-    ffi (1.9.10-x64-mingw32)
-    jekyll (3.0.1)
-      colorator (~> 0.1)
+    colorator (1.1.0)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.3.0)
-      listen (~> 3.0)
-    kramdown (1.9.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.12.0)
     liquid (3.0.6)
-    listen (3.0.5)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rouge (1.10.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.22)
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
-  jekyll (~> 3.0.0)
+  jekyll (~> 3.2.1)
 
 BUNDLED WITH
-   1.10.6
+   1.13.3


### PR DESCRIPTION
I am hoping to contribute soon. I checked the code out, however, I hit a problem as Jekyll is pessimistically versioned, and the dependencies of the newer version don't match that in the `Gemfile.lock`.

After looking up the current GH Pages version (3.2.1), I set out to get this updated safely, and it seems to have been fine. It works in my development environment now and appears as though it will be fully supported by GitHub pages. 