### PR TITLE
Add Basic Print Stylesheet

### DIFF
--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,0 +1,45 @@
+@media print {
+  @page {
+    margin: 0.5cm;
+  }
+
+  article {
+    a:after {
+      content: ' ( ' attr(href) ' ) ';
+    }
+
+    .button-edit {
+      display: none !important;
+    }
+
+    code {
+      font-family: monospace;
+    }
+  }
+
+  ul.nav {
+    li a {
+      display: none;
+    }
+
+    li.logo a {
+      display: block;
+    }
+  }
+
+  .button-edit {
+    display: none;
+  }
+
+  article {
+    width: 100%;
+  }
+  
+  section#related {
+    display: none;
+  }
+
+  footer {
+    display: none;
+  }
+}

--- a/css/master.scss
+++ b/css/master.scss
@@ -9,3 +9,4 @@
 @import "typography";
 @import "header";
 @import "footer";
+@import "print";


### PR DESCRIPTION
As per the discussion (https://github.com/a11yproject/a11yproject.com/issues/429), I've attempted a simple print stylesheet.

It's not meant to cover everything, but I've tried to make it look ok when an article is printed.

I've not done this before, so I'd appreciate as much feedback as possible!

Here's an example of a printed page with these styles applied; 
[MYTH_ Screen readers don’t use JavaScript - The A11Y Project.pdf](https://github.com/a11yproject/a11yproject.com/files/560374/MYTH_.Screen.readers.don.t.use.JavaScript.-.The.A11Y.Project.pdf)
