### PR TITLE
Fix Toc JS bug

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -30,11 +30,6 @@ $(document).ready(function(){
   }
 
   function removeWaypoints(element) {
-    // waypoint classes that need to be added
-    $(element).removeClass('waypoint-section');
-
-    // get the ID of the section
-    var id = $(element).attr('id');
     // destroys all active waypoints
     Waypoint.destroyAll();
   }
@@ -59,8 +54,9 @@ $(document).ready(function(){
     var windowWidth = $(window).width() / parseFloat($("html").css("font-size"));
 
     if(windowWidth < 53) { // accordion view
+
       // remove waypoints and waypoint semantics
-      removeWaypoints(element);
+      removeWaypoints();
 
     } else { // desktop view
 


### PR DESCRIPTION
I noticed that on small screens and when resizing the browser the `tocPageSemantics()` function was throwing an error. This was breaking the footer and other JS.

- Left the `.waypoint-section` classes in markup.. not hurting anything.
- Removed the unneeded variable definition line `#37`
- Removed undefined variable passed as argument line `#58"