### PR TITLE
Improve code readability

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -88,6 +88,7 @@ pre {
 
 code {
     background: $grayLighter;
+    font-family: 'Source Code Pro', Consolas, Monaco, 'Courier New', monospace;
     padding: 0.1em 0.25em;
 }
 

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -89,6 +89,7 @@ pre {
 code {
     background: $grayLighter;
     font-family: 'Source Code Pro', Consolas, Monaco, 'Courier New', monospace;
+    font-size: 80%;
     padding: 0.1em 0.25em;
 }
 

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -77,6 +77,7 @@ ol {
 
 pre {
     background: $grayLighter;
+    line-height: 1.6;
     padding: 1em;
     white-space: pre-wrap;       /* CSS 3 */
     white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -86,6 +86,9 @@ pre {
     word-wrap: break-word;
     margin-bottom: 1.4em;
 }
+pre code {
+  background: none;
+}
 
 code {
     background: $grayLighter;


### PR DESCRIPTION
#### Problem

Readability of of inline and block code on <a11yproject.com> isn’t great primarily because it’s set in the body type, a san-serif face. This is especially noticeable on [“Getting started with ARIA”](http://a11yproject.com/posts/getting-started-aria/). Code is traditionally set in a monospaced face.

#### Solution

* Address the issues by changing `code` elements’ `font-family` to a cross-OS-friendly monospace font stack.
* Decrease `code`’s `font-size` to make reading inline elements less jarring.
* Decrease `pre`’s `line-height` to make reading code blocks easier.
* _Bonus:_ remove redundant background color on `code`s nested inside `pre`s.

These are broken into (excessively?) granular commits. I’d be happy to rebase, change the font stack, drop a commit, etc.

#### Testing

```shell
git clone git@github.com:swashcap/a11yproject.com.git wat-is-code
cd wat-is-code
bundle install
jekyll serve
```

Then, go to http://localhost4000:/posts/getting-started-aria/ and check out the inline and block code.

#### Screenshots

Before:

![before](https://cloud.githubusercontent.com/assets/1858316/23592170/bb9167a0-01b1-11e7-81c3-1cce7a1eafda.jpg)

After:

![after](https://cloud.githubusercontent.com/assets/1858316/23592171/bf079418-01b1-11e7-9106-248982eef1ec.jpg)