### PR TITLE
Update resource url.

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -66,7 +66,7 @@
     - url: http://dylanb.github.io/periodic-aria-roles.html
       title: "Periodic Table of ARIA roles"
       description: "By dylanb"
-    - url: http://www.w3.org/WAI/PF/aria-practices/
+    - url: https://www.w3.org/TR/wai-aria-practices/
       title: "Recommended ARIA usage by feature"
       description: "By W3C"
     - url: http://rawgithub.com/w3c/aria-in-html/master/index.html


### PR DESCRIPTION
The original resource url points to a page saying its not to be used and links to the new url provided.