### PR TITLE
update heading nesting

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -164,6 +164,7 @@ $mobile: 24em;
 }
 
 .excerpt-list__title {
+    font-size: 1.33em;
     margin-bottom: .2em;
 }
 

--- a/index.html
+++ b/index.html
@@ -20,14 +20,13 @@ description: A community-driven effort to make web accessibility easier.
   {% assign posts = category.last %}
 
   <section id="{{ title | capitalize | replace:' ','-' }}" class="article-section archive-section" tabindex="-1">
-
-
     <h2 class="article-section__title">{{ title | capitalize }}</h2>
     <ul class="article-section__content excerpt-list">
     {% for post in posts %}
       <li>
-        <h4 class="excerpt-list__title"><a href="{{ post.url }}">{{ post.title }}</a></h4>
+        <h3 class="excerpt-list__title"><a href="{{ post.url }}">{{ post.title }}</a></h3>
         {% if post.description %}<p>{{ post.description }}</p>{% endif %}
+      </li>
     {% endfor %}
   </section>
 


### PR DESCRIPTION
[per issue 483](https://github.com/a11yproject/a11yproject.com/issues/483)

update level 4 headings to level 3 as that would be the expected nesting order after a level 2 heading.

update .excerpt-list__title class to have the same font-size as the h4 selector, to maintain visual consistency.

This commit also contains adding a closing </li> tag for the category posts, as closing </li>s are used for other lists on the site, and this will fix HTML validation errors that are being reported by the browser.