### PR TITLE
fix invalid <ul> nesting

### DIFF
--- a/patterns.html
+++ b/patterns.html
@@ -23,21 +23,19 @@ permalink: patterns.html
     <h3 class="article-section__title">{{ category.pattern-category }}</h3>
     <ul class="article-section__content">
       {% if category.sub-category %}
-        <ul>
-          <li>
-            {{category.sub-category}}
-            <ul>
-              {% assign sorted_subcategory = (category.sub-category-patterns | sort: 'title') %}
-              {% for pattern in sorted_subcategory %}
-                <li>
-                  <a href="{{ pattern.url }}" rel="external">
-                    {{pattern.title}}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
-        </ul>
+        <li>
+          {{category.sub-category}}
+          <ul>
+            {% assign sorted_subcategory = (category.sub-category-patterns | sort: 'title') %}
+            {% for pattern in sorted_subcategory %}
+              <li>
+                <a href="{{ pattern.url }}" rel="external">
+                  {{pattern.title}}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </li>
       {% endif %}
       {% assign sorted_category = (category.patterns | sort: 'title') %}
       {% for pattern in sorted_category %}


### PR DESCRIPTION
this update removes inappropriate nesting of <ul> elements when a pattern category contains sub-categories.

the HTML output resulted in the following:
```
<ul>
<ul>
…
```
this fix removes the unnecessary, second ul.