### PR TITLE
Add accessible error messages pattern

### DIFF
--- a/_data/patterns.yml
+++ b/_data/patterns.yml
@@ -91,6 +91,12 @@
     - url: "http://github.com/paypal/accessible-html5-video-player/"
       title: "Accessible HTML5 Video Player"
 
+- pattern-category: Error Messages
+  section-id: error-messages
+  patterns:
+    - url: "https://hiddedevries.nl/en/blog/2017-04-04-how-to-make-error-messages-accessible"
+      title: "How to make error messages accessible"
+
 - pattern-category: Other
   section-id: other
   patterns:


### PR DESCRIPTION
Adding @hiddedevries’ tutorial for creating accessible error messages. This PR does not follow the contribution guidelines by not including a live demo, but I’ve noticed a few other submissions have been accepted as blog posts/tutorials.