### PR TITLE
revise toc nav markup and labeling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 layout: archives
 description: A community-driven effort to make web accessibility easier.
 ---
-<section class="toc-wrap">
-  <h3 class="toc-title">Categories</h3>
+<nav class="toc-wrap" aria-labelledby="toc_title">
+  <h2 id="toc_title" class="toc-title">Categories</h2>
   <ul class="toc">
     {% for category in site.categories %}
       {% assign title = category.first %}
@@ -12,7 +12,7 @@ description: A community-driven effort to make web accessibility easier.
 
     {% endfor %}
   </ul>
-</section>
+</nav>
 
 {% for category in site.categories %}
 

--- a/patterns.html
+++ b/patterns.html
@@ -5,8 +5,8 @@ description: An accessible widget & pattern library
 permalink: patterns.html
 ---
 
-<section class="toc-wrap toc-long">
-    <h3 class="toc-title">Categories</h3>
+<nav class="toc-wrap toc-long" aria-labelledby="toc_title">
+    <h2 id="toc_title" class="toc-title">Categories</h2>
     <ul class="toc">
         {% for category in site.data.patterns %}
         <li>
@@ -16,7 +16,7 @@ permalink: patterns.html
         </li>
         {% endfor %}
     </ul>
-</section>
+</nav>
 
 {% for category in site.data.patterns  %}
 <section id="{{category.section-id}}" class="article-section patterns-section" tabindex="-1">

--- a/resources.html
+++ b/resources.html
@@ -5,8 +5,8 @@ description: Accessibility software, books, blogs, online tools, and more
 permalink: resources.html
 ---
 
-<section class="toc-wrap toc-long">
-    <h3 class="toc-title">Categories</h3>
+<nav class="toc-wrap toc-long" aria-labelledby="toc_title">
+    <h2 id="toc_title" class="toc-title">Categories</h2>
     <ul class="toc">
         {% for category in site.data.resources %}
         <li>
@@ -16,7 +16,7 @@ permalink: resources.html
         </li>
         {% endfor %}
     </ul>
-</section>
+</nav>
 
 {% for category in site.data.resources %}
 <section id="{{category.section-id}}" class="article-section resources-section" tabindex="-1">


### PR DESCRIPTION
[per issue #514](https://github.com/a11yproject/a11yproject.com/issues/514)  

• set table of contents navigations to be nav landmarks with an aria-labelledby pointing to their containted heading element.

• update heading helement from `<h3>` to `<h2>` so a heading level is not skipped in the document.