### PR TITLE
fix heading order

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -37,11 +37,13 @@ h3 {
     font-size: 1.66em;
 }
 
-h4 {
+h4,
+.txt-up-2 {
     font-size: 1.33em;
 }
 
-h5 {
+h5,
+.txt-up-1 {
     font-size: 1.125em;
 }
 

--- a/archives.html
+++ b/archives.html
@@ -16,7 +16,7 @@ permalink: archives.html
   {% for post in posts %}
     <div class="media">
       <div class="media-body">
-        <h4 class="media-heading"><a href="{{ post.url }}">{{ post.title }}</a></h4>
+        <h3 class="txt-up-2"><a href="{{ post.url }}">{{ post.title }}</a></h3>
         {% if post.description %}<p>{{ post.description }}</p>{% endif %}
       </div>
     </div>

--- a/archives.html
+++ b/archives.html
@@ -16,7 +16,7 @@ permalink: archives.html
   {% for post in posts %}
     <div class="media">
       <div class="media-body">
-        <h3 class="txt-up-2"><a href="{{ post.url }}">{{ post.title }}</a></h3>
+        <h3 class="media-heading txt-up-2"><a href="{{ post.url }}">{{ post.title }}</a></h3>
         {% if post.description %}<p>{{ post.description }}</p>{% endif %}
       </div>
     </div>


### PR DESCRIPTION
heading level 3 is currently skipped on the archive page.

this commit updates the CSS to include some utility classes, to allow us to modify font-sizes to match headings, without the need to use those headings.

It also fixes the heading element in the markup.

Per [issue 519](https://github.com/a11yproject/a11yproject.com/issues/519)