### PR TITLE
Improve support for visually-hidden but focusable content

### DIFF
--- a/_posts/2013-01-11-how-to-hide-content.md
+++ b/_posts/2013-01-11-how-to-hide-content.md
@@ -42,10 +42,10 @@ There may be cases where you want to use `aria-hidden` and also visually hide th
         display: none; 
     }
     
- Another way to hide content both visually and from assistive technology is the [HTML `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages:
+ Another way to hide content both visually and from assistive technology is the [HTML5 `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages:
  
      [hidden] { display: none; }
      
-See the artilce *[HTML5 hidden Attribute](https://davidwalsh.name/html5-hidden)* for more information on the `hidden` attribute.
+See the artilce *[HTML5 Hidden Attribute](https://davidwalsh.name/html5-hidden)* for more information on the `hidden` attribute.
     
 

--- a/_posts/2013-01-11-how-to-hide-content.md
+++ b/_posts/2013-01-11-how-to-hide-content.md
@@ -9,29 +9,16 @@ categories:
   - How-tos
 ---
 
-Developers commonly use `display: none` to hide content on the page. Unfortunately, this simple and common action is a bit problematic for screen readers.
+Developers commonly use `display: none` to hide content on the page. Unfortunately, this simple and common action can be problematic for users of screen readers.
 
-[Screen readers sometimes ignore display:none](http://www.456bereastreet.com/archive/200711/screen_readers_sometimes_ignore_displaynone/)[^bereast]. This means the content will be read despite being "hidden". To hide content completely from screen readers use the following:
+There are also real world situations where you want to visually hide elements (e.g., a `form label`), but you still want text to be read by a screen reader. The "clip pattern" will hide the content visually, yet provide the content to screen readers[^clip]. Unlike positioning and negative text-indent, it works with rtl languages for localization.
 
-    /* http://www.456bereastreet.com/archive/200711/screen_readers_sometimes_ignore_displaynone/ */
-    .hidden {
-        display:none;
-        visibility:hidden;
-    }
-
-And for good measure you could consider adding the ARIA attribute `aria-hidden="true"` to the element.
-
-There are also real world situations where you want to hide elements (e.g., a `form label`), but you still want text to be read by a screen reader. The "clip pattern" will hide the content visually, yet provide the content to screen readers[^clip]. Unlike positioning and negative text-indent, it works with rtl languages for localization.
-
-    .visually-hidden { /*https://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html*/
+    .visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
         position: absolute !important;
+        height: 1px; width: 1px; 
+        overflow: hidden;
         clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
         clip: rect(1px, 1px, 1px, 1px);
-        padding:0 !important;
-        border:0 !important;
-        height: 1px !important;
-        width: 1px !important;
-        overflow: hidden;
     }
     
 It is possible to apply the `.visually-hidden` class to content that contains nativily focusable elements (such as `a`, `button`, `input`, etc). It is important to still show these elements visually when they recieve focus, otherwise a keyboard-only users might not know what has focus. CSS for this might look something like:
@@ -40,5 +27,21 @@ It is possible to apply the `.visually-hidden` class to content that contains na
 
 Consider adding these HTML classes and CSS rules to your base stylesheet and use them when applicable.
 
-[^bereast]: [Screen readers sometimes ignore display:none](http://www.456bereastreet.com/archive/200711/screen_readers_sometimes_ignore_displaynone/) 456 Berea Street (November 7, 2007)
-[^clip]: [Clip Your Hidden Content For Better Accessibility](http://web.archive.org/web/20160616144545/https://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html) Yahoo Accessibility Blog  (October 23, 2012)
+## Alternatives to `display: none`
+
+The `aria-hidden="true"` HTML attribute is the logical oposite of the `.visually-hidden` class. It hides content from assistive technology, but not visually. This can be helpful in cases where there are visual cues that screen readers do not need to speak, such as icons (although you should provide some form of alternative text for icons).
+
+There may be cases where you want to use `aria-hidden` and also visually hide the content. This can be accomplished with some CSS like:
+
+    .my-compnent[aria-hidden="true"] { 
+        display: none; 
+    }
+    
+ Another way to hide content both visually and from assistive technology is the [HTML `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages[^hidden]:
+ 
+     *[hidden] { display: none; }
+    
+
+[^clip]: [Hiding Content for Accessibility](https://snook.ca/archives/html_and_css/hiding-content-for-accessibility) Yahoo Accessibility Blog  (Feburary 25, 2011)
+[^hidden]: [HTML5 hidden Attribute](https://davidwalsh.name/html5-hidden) DWB (September 20, 2012)
+

--- a/_posts/2013-01-11-how-to-hide-content.md
+++ b/_posts/2013-01-11-how-to-hide-content.md
@@ -33,7 +33,10 @@ There are also real world situations where you want to hide elements (e.g., a `f
         width: 1px !important;
         overflow: hidden;
     }
-    body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .visually-hidden button { display: none !important; }
+    
+It is possible to apply the `.visually-hidden` class to content that contains nativily focusable elements (such as `a`, `button`, `input`, etc). It is important to still show these elements visually when they recieve focus, otherwise a keyboard-only users might not know what has focus. CSS for this might look something like:
+
+    .visually-hidden a:focus, .visually-hidden input:focus, .visually-hidden button:focus { position:static; width:auto; height:auto;  }
 
 Consider adding these HTML classes and CSS rules to your base stylesheet and use them when applicable.
 

--- a/_posts/2013-01-11-how-to-hide-content.md
+++ b/_posts/2013-01-11-how-to-hide-content.md
@@ -11,7 +11,7 @@ categories:
 
 Developers commonly use `display: none` to hide content on the page. Unfortunately, this simple and common action can be problematic for users of screen readers.
 
-There are also real world situations where you want to visually hide elements (e.g., a `form label`), but you still want text to be read by a screen reader. The "clip pattern" will hide the content visually, yet provide the content to screen readers[^clip]. Unlike positioning and negative text-indent, it works with rtl languages for localization.
+There are real world situations where you might need to hide elements visually (e.g., a form `label`), but keep the element text available to be announced by a screen reader. The "clip pattern" accomplishes this task for you; hide the content visually, yet provide the content to screen readers. Unlike CSS positioning and negative text-indent techniques, the "clip pattern" also works with RTL (Right-to-left) languages for localization. See the article *[Hiding Content for Accessibility](https://snook.ca/archives/html_and_css/hiding-content-for-accessibility)* for more information on the visually-hidden pattern.
 
     .visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
         position: absolute !important;
@@ -21,15 +21,20 @@ There are also real world situations where you want to visually hide elements (e
         clip: rect(1px, 1px, 1px, 1px);
     }
     
-It is possible to apply the `.visually-hidden` class to content that contains nativily focusable elements (such as `a`, `button`, `input`, etc). It is important to still show these elements visually when they recieve focus, otherwise a keyboard-only users might not know what has focus. CSS for this might look something like:
+It is possible to apply the `.visually-hidden` class to content that contains natively focusable elements (such as `a`, `button`, `input`, etc). It's important to show these elements visually when they receive focus, otherwise a keyboard-only user might not know which element currently has focus. CSS for this might look something like:
 
-    .visually-hidden a:focus, .visually-hidden input:focus, .visually-hidden button:focus { position:static; width:auto; height:auto;  }
+    .visually-hidden a:focus,
+    .visually-hidden input:focus,
+    .visually-hidden button:focus { 
+        position:static; 
+        width:auto; height:auto;  
+    }
 
 Consider adding these HTML classes and CSS rules to your base stylesheet and use them when applicable.
 
 ## Alternatives to `display: none`
 
-The `aria-hidden="true"` HTML attribute is the logical oposite of the `.visually-hidden` class. It hides content from assistive technology, but not visually. This can be helpful in cases where there are visual cues that screen readers do not need to speak, such as icons (although you should provide some form of alternative text for icons).
+The `aria-hidden="true"` HTML attribute is the logical oposite of the `.visually-hidden` class. It hides content from assistive technology, but not visually. This can be helpful in cases where there are visual cues that screen readers do not need to announce, such as icons (although you should provide some form of alternative text for icons).
 
 There may be cases where you want to use `aria-hidden` and also visually hide the content. This can be accomplished with some CSS like:
 
@@ -37,11 +42,10 @@ There may be cases where you want to use `aria-hidden` and also visually hide th
         display: none; 
     }
     
- Another way to hide content both visually and from assistive technology is the [HTML `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages[^hidden]:
+ Another way to hide content both visually and from assistive technology is the [HTML `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages:
  
-     *[hidden] { display: none; }
+     [hidden] { display: none; }
+     
+See the artilce *[HTML5 hidden Attribute](https://davidwalsh.name/html5-hidden)* for more information on the `hidden` attribute.
     
-
-[^clip]: [Hiding Content for Accessibility](https://snook.ca/archives/html_and_css/hiding-content-for-accessibility) Yahoo Accessibility Blog  (Feburary 25, 2011)
-[^hidden]: [HTML5 hidden Attribute](https://davidwalsh.name/html5-hidden) DWB (September 20, 2012)
 


### PR DESCRIPTION
Fixes https://github.com/a11yproject/a11yproject.com/issues/499

Some other notes/questions about this article and PR:

- It might be good to reference a newer article than the deleted yahoo article for the `.visually-hidden` class.
- I don't think we have to worry about `display:none` not working for screen readers anymore. The post that was referencing that as an issue is 10 years old and I don't think it is an issue anymore. In my experience, this is no longer an problem, and I haven't been able to find any more recent articles indicating that it is still a problem.
- Adding `aria-hidden` in addition to `display:none` is over doing it in my opinion, and can lead mistakes in the future (update css to remove `display:none` but forget to remove the `aria-hidden`). I recommend removing this part, and perhaps referencing the `hidden` HTML attribute as another way of hiding content.

Should I make all, some, or none of these additional changes to this PR? 