### PR TITLE
Remove role="navigation" from example

### DIFF
--- a/_posts/2014-05-15-getting-started-aria.md
+++ b/_posts/2014-05-15-getting-started-aria.md
@@ -64,7 +64,7 @@ To create accessible applications, basic principles of semantic HTML, keyboard s
 ## ARIA Examples
 
 * Landmark role
-  The `<nav>` element has been given a landmark role allowing screen reader users navigate directly to this element.
+  The `<nav>` element implicitly has landmark role of `navigation` allowing screen reader users navigate directly to this element. [Discussion on implicit html5 landmarks](http://a11yproject.com/posts/aria-landmark-roles/)
 
 ~~~~~~~~
     <nav>

--- a/_posts/2014-05-15-getting-started-aria.md
+++ b/_posts/2014-05-15-getting-started-aria.md
@@ -64,7 +64,7 @@ To create accessible applications, basic principles of semantic HTML, keyboard s
 ## ARIA Examples
 
 * Landmark role
-  The `<nav>` element implicitly has landmark role of `navigation` allowing screen reader users navigate directly to this element. [Discussion on implicit html5 landmarks](http://a11yproject.com/posts/aria-landmark-roles/)
+  The `<nav>` element implicitly has a landmark role of `navigation` allowing screen reader users to navigate directly to this element. Review the article [Quick Tip: Aria Landmark Roles and HTML5 Implicit Mapping](http://a11yproject.com/posts/aria-landmark-roles/) for more information. 
 
 ~~~~~~~~
     <nav>

--- a/_posts/2014-05-15-getting-started-aria.md
+++ b/_posts/2014-05-15-getting-started-aria.md
@@ -67,7 +67,7 @@ To create accessible applications, basic principles of semantic HTML, keyboard s
   The `<nav>` element has been given a landmark role allowing screen reader users navigate directly to this element.
 
 ~~~~~~~~
-    <nav role="navigation">
+    <nav>
       <ul>
         <li>
           <a href="/">Home</a>


### PR DESCRIPTION
There is some contention about whether or not `<nav>` is semantically the same as `<nav role="navigation">`, but the October 2014 version of the HTML spec seems to indicate it shouldn't be set:

https://www.w3.org/TR/html5/sections.html#the-nav-element

Even if `<nav>` implicitly having the "navigation" landmark isn't fully implemented by all screen readers, I would think this documentation should be aspirational, showing how things will be.

Having `<nav role="navigation">` contradicts the important, and I think generally hard to grasp the idea, that redundant roles should not be used. Part of the reason it is hard to grasp due to a proliferation of incorrect examples.

That being said having `role="navigation"` still may be practical and a good idea currently, but if so my feeling is that should be explained.