### PR TITLE
Add a desktop footer top margin when ToC detaches

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -53,6 +53,10 @@ $mobile: 24em;
             z-index: 2;
         }
 
+        .footer {
+            margin-top: 6em;
+        }
+
         .post {
             // widen it up to make room
             max-width: ($tablet+11em);


### PR DESCRIPTION
This PR fixes https://github.com/a11yproject/a11yproject.com/issues/564.

At the desktop breakpoint it adds a little top margin to the footer, removing the truncation effect of the side nav. It's a bit of a magic number, but I think since the space is uniform on every page with a footer it will feel more unified and less hacky.