### PR TITLE
Add a 24 hour buffer before an event is moved

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -432,7 +432,7 @@ $(document).ready(function(){
           var events = [].slice.call(document.querySelectorAll('[data-date]'));
           /* Loops through event array, returns past that occured after current date */
           var eventTimes = events.filter(function (el) {
-            return el.dataset.date < now;
+            return el.dataset.date < now - 86400; // `86400` is 24 hours in Unix time (60 * 60 * 24)
           })
           return eventTimes;
       }


### PR DESCRIPTION
This PR addresses https://github.com/a11yproject/a11yproject.com/issues/566.

I created a test event for today to test around 2:00 PM, and the logic seemed to hold. Same for changing its date to one day in the past. I'd still appreciate a second set of eyes on it, though, as I'm not too comfortable with JS stuff.