### PR TITLE
DL Style Changes

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -65,6 +65,13 @@ a img {
     border: 0;
 }
 
+dd{
+    padding-left: 1em;
+}
+dt{
+    font-weight: bold; 
+}
+
 html {
     box-sizing: border-box;
 }


### PR DESCRIPTION
When I was reviewing the site, the definition lists just turned into plaintext. This fix will make it more obvious to sighted users when there is a `<dl>`.