### PR TITLE
Quick test: Check contrast with your mobile device article edits

### DIFF
--- a/_posts/2013-01-22-check-contrast-with-mobile-device.md
+++ b/_posts/2013-01-22-check-contrast-with-mobile-device.md
@@ -3,6 +3,7 @@ title: "Quick test: Check contrast with your mobile device"
 description: "Using an ordinary mobile device you can check your site's readability."
 author: dave_rupert
 layout: post
+last_updated: 2018-11-24
 categories:
     - Quick Tests
 ---
@@ -20,6 +21,8 @@ If you find something difficult to read, you may have found an accessibility iss
 ## Available Tools
 
 - [Check My Colours](http://www.checkmycolours.com/)
+- [Contrast for macOS](https://usecontrast.com/)
 - [WebAIM: Color Contrast Checker](https://webaim.org/resources/contrastchecker/)
 - [Axe: Open Source Library for Web Accessibility Testing](https://www.deque.com/axe/)
 - [Tenon.io](https://tenon.io/)
+- [TPG: Colour Contrast Analyser](https://developer.paciellogroup.com/resources/contrastanalyser/)

--- a/_posts/2013-01-22-check-contrast-with-mobile-device.md
+++ b/_posts/2013-01-22-check-contrast-with-mobile-device.md
@@ -7,9 +7,19 @@ categories:
     - Quick Tests
 ---
 
-Having good contrast and readability are an important part of creating an accessible website. One trick you can do to test whether or not your contrast is sufficient enough is by using your phone or mobile device.
+Having good contrast and readability are an important part of creating an accessible website. 
+
+One trick you can do to test whether or not your contrast is sufficient enough is by using your phone or mobile device.
 
 1. Set the brightness of your mobile device to its lowest setting.
 1. Open up your website on the device and begin browsing around.
+1. Optionally, try viewing your site in direct sunlight.
 
-If you find something difficult to read, congratulations, you may have found an accessibility issue! Take measures to [check and increase the contrast of your text](http://www.checkmycolours.com/).
+If you find something difficult to read, you may have found an accessibility issue! Take measures to check and increase the contrast of your text.
+
+## Available Tools
+
+- [Check My Colours](http://www.checkmycolours.com/)
+- [WebAIM: Color Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [Axe: Open Source Library for Web Accessibility Testing](https://www.deque.com/axe/)
+- [Tenon.io](https://tenon.io/)


### PR DESCRIPTION
This PR addresses the audit efforts in #669.

It break up the lede paragraph. Ledes are traditionally supposed to be on the shorter side, 1-2 sentences to draw the reader in, then start to discuss the article in earnest. 

It also adds a tool list section with a few additional resources. We may want to standardize the terminology for our resources/additional reading sections following an article. It might also be an opportunity to create a styleguide component, as it's a repeated content pattern.