### PR TITLE
Quick tip: Never use maximum-scale=1.0 article updates

### DIFF
--- a/_posts/2013-01-14-never-use-maximum-scale.md
+++ b/_posts/2013-01-14-never-use-maximum-scale.md
@@ -9,22 +9,30 @@ categories:
   - Quick Tips
 ---
 
+Using the viewport meta tag the wrong way can prevent people with low vision concerns from accessing your website. 
+
 ## About the `maximum-scale` attribute
-Using the viewport meta tag the wrong way can hinder users with visual problems accessing your website. By setting `maximum-scale=1.0`, you are disabling the functionality to use pinch zoom on mobile devices, and forcing users to view your page a certain way.
 
-The **bad** way:
+By setting `maximum-scale=1.0`, you are disabling the functionality to use pinch zoom on certain mobile devices, forcing people to view your page a certain way.
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+### The bad way:
 
+``` html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+```
 
-The **good** way:
+### The good way:
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+``` html
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+```
 
-
-Avoiding `maximum-scale=1.0` allows your site to meet users' needs and provide a better experience.
+Avoiding `maximum-scale=1.0` allows your site to meet users' needs and provide a better experience. Note that declarations of `user-scalable`, `min-scale`, and `max-scale` are [ignored as of iOS 10](https://webkit.org/blog/7367/new-interaction-behaviors-in-ios-10/). It is still recommended that these declarations are avoided, to support older iOS devices as well as non Apple products.	
 
 ## About the `user-scalable` attribute
-The `user-scalable` attribute can likewise cause problems for users who use the built-in zoom functionality of their web browser. The attribute is set as `user-scalable=yes` by default, which means that users are able to control the zoom setting on a webpage. Changing it to `user-scalable=no` would prevent desktop users' zoom settings from applying to a webpage and prevent mobile users from using pinch zoom.
 
-Avoid setting `user-scalable` to `no` to assure better accessibility of your site; either leave it as defaulted by not referencing the `user-scalable` attribute or set it to `yes`.
+The `user-scalable` attribute can also [cause problems](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#Viewport_scaling) for people who use the built-in zoom functionality of their web browser. 
+
+The attribute is set as `user-scalable="yes"` by default, which means that people are able to control the zoom setting on a webpage. Changing it to `user-scalable="no"` would prevent zoom settings from working on both mobile and desktop devices.
+
+Avoid setting `user-scalable` to `no` to assure better accessibility of your site. Either leave it as default by not referencing the `user-scalable` attribute, or set it to `yes`.

--- a/_posts/2013-01-14-never-use-maximum-scale.md
+++ b/_posts/2013-01-14-never-use-maximum-scale.md
@@ -3,13 +3,14 @@ layout: post
 title: "Quick tip: Never use <code>maximum-scale=1.0</code>"
 description: "Why you never ever should use <code>maximum-scale=1.0</code> in your viewport meta tag."
 author: thomas_sjogren
-# date:
-# last_updated:
+date: 2013-01-14
+updated_by: eric_bailey
+last_updated: 2018-11-24
 categories:
   - Quick Tips
 ---
 
-Using the viewport meta tag the wrong way can prevent people with low vision concerns from accessing your website. 
+Using the viewport meta tag the wrong way can prevent people with low vision concerns from accessing your website or web app. 
 
 ## About the `maximum-scale` attribute
 
@@ -27,12 +28,12 @@ By setting `maximum-scale=1.0`, you are disabling the functionality to use pinch
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 ```
 
-Avoiding `maximum-scale=1.0` allows your site to meet users' needs and provide a better experience. Note that declarations of `user-scalable`, `min-scale`, and `max-scale` are [ignored as of iOS 10](https://webkit.org/blog/7367/new-interaction-behaviors-in-ios-10/). It is still recommended that these declarations are avoided, to support older iOS devices as well as non Apple products.	
+Avoiding `maximum-scale=1.0` allows your site to meet users' needs and provide a better experience. Note that declarations of `user-scalable`, `min-scale`, and `max-scale` are [ignored as of iOS 10](https://webkit.org/blog/7367/new-interaction-behaviors-in-ios-10/). It is still recommended that these declarations are avoided, to support older iOS devices as well as non-Apple products that may respect the meta tag.	
 
 ## About the `user-scalable` attribute
 
 The `user-scalable` attribute can also [cause problems](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#Viewport_scaling) for people who use the built-in zoom functionality of their web browser. 
 
-The attribute is set as `user-scalable="yes"` by default, which means that people are able to control the zoom setting on a webpage. Changing it to `user-scalable="no"` would prevent zoom settings from working on both mobile and desktop devices.
+The attribute is set as `user-scalable="yes"` by default, which means that people are able to control the zoom setting for the page theyre visiting. Changing it to `user-scalable="no"` would prevent zoom settings from working on both mobile and desktop devices.
 
 Avoid setting `user-scalable` to `no` to assure better accessibility of your site. Either leave it as default by not referencing the `user-scalable` attribute, or set it to `yes`.


### PR DESCRIPTION
This PR addresses the audit efforts in #669. It:

- Adds a lede paragraph to standardize it, and shifts paragraph breaks around slightly for better flow
- References "people" in place of "users" where possible, to better align with [our content styleguide](https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CONTENT_STYLE_GUIDE.md#user-or-person)
- Adds subheadings to section example code content
- Adds a reference to iOS dropping support for `user-scalable`, `min-scale`, and `max-scale`