### PR TITLE
Adding no width space before li elements

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -10,9 +10,16 @@
     text-align: center;
 }
 
-%no-list-style {
+@mixin no-list-style-mixin() {
     padding-left: 0;
     list-style: none;
+    li:before {
+        content: "\200B"; /* add zero-width space */
+    }
+}
+
+%no-list-style {
+    @include no-list-style-mixin();
 }
 
 .inline-list {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -92,8 +92,7 @@ $mobile: 24em;
             }
 
             .toc {
-                list-style: none;
-                padding-left: 0;
+                @include no-list-style-mixin();
                 text-align: right;
             }
 


### PR DESCRIPTION
Addresses Issue #685 

I found a [placeholder selector](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#placeholder_selectors_foo): ```%no-list-style```, that seems to be used in a number of places. I thought, that I could just add the proposed CSS from the [blog post linked in the issue](https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/), to ```%no-list-style```, and be done.

Unfortunately, the table of contents applies ```list-style: none``` via a media query, and SASS does not let you extend a placeholder selector inside of a media query, so I went with the solution suggested [here](https://lazamar.github.io/exdending-classes-within-media-queries-in-scss/), and:
- Made a [mixin](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins):```no-list-style-mixin``` with all of the properties of the ```no-list-style``` placeholder selector
- Added the proposed CSS solution to the ```no-list-style-mixin```
- Replaced the content of the ```no-list-style``` placeholder selector with ```no-list-style-mixin```, so that the mixin is used wherever the placeholder selector is currently used
- Added the ```no-list-style-mixin``` to the ```.toc``` class to apply to the table of contents, since you can use mixins inside of media queries