### PR TITLE
A primer to vestibular disorders article audit

### DIFF
--- a/_posts/2013-05-15-understanding-vestibular-disorders.md
+++ b/_posts/2013-05-15-understanding-vestibular-disorders.md
@@ -7,26 +7,29 @@ published: true
 categories:
   - Background
 ---
->**Vestibular system** — n
->The sensory mechanism in the inner ear that detects movement of the head and helps to control balance.
 
-Imagine a world where your internal gyroscope is not working properly. Very similar to being intoxicated, things seem to move of their own accord, your feet never quite seem to be stable underneath you, and your senses are moving faster or slower than your body.
+Your Vestibular system us the sensory mechanism in the inner ear that detects movement of the head and helps to control balance.
 
-Your personal steady-cam is broken and whatever you look at tends to move regardless if you are moving. Let's take that feeling and check out that great new website with animations and parallax scrolling. Does your stomach want to jump out of your throat? Well for many people it does.
+Imagine a world where your internal gyroscope is not working properly. Very similar to being intoxicated, things seem to move of their own accord, your feet never quite seem to be stable underneath you, and your senses are moving faster or slower than the rest of syour body.
+
+Your personal steady-cam is broken. Whatever you look at tends to move regardless of if you are moving. Let's take that feeling and check out that great new website with animations and parallax scrolling. Does your stomach want to jump out of your throat? Well for many people it does.
 
 ## What is it?
 
 People with vestibular disorders have a problem with their inner ear. It affects their balance as well as their visual perception of their world around them.
 
-Sometimes the sensation lasts only a short while, but others can suffer it for years. Walking becomes a challenge and they have a constant risk of falling. Concentration is diminished leaving the sufferer unfocused and often unproductive. It is often viewed as a "hidden" disability because it has no outward showing symptoms.
+Sometimes the sensation lasts only a short while, but others can experience it for years. Walking can become a challenge and they may experience a constant risk of falling. Concentration can be diminished, leaving a person unfocused and consequently unproductive. It is often viewed as a "hidden" disability because it has no outward showing symptoms.
 
 ## Who is at risk?
 
-The cause may be from illness, injury, or from a genetic anomaly but anyone can suffer from a vestibular disorder. According to [vestibular.org](https://vestibular.org/understanding-vestibular-disorder), a resource for people with vestibular disorders, as many as 35% of adults aged 40 years or older in the United States have experienced some form of vestibular dysfunction.
+The cause may be from illness, injury, or a genetic condition, but anyone can suffer from a vestibular disorder. According to [vestibular.org](https://vestibular.org/understanding-vestibular-disorder), a resource for people with vestibular disorders, as many as 35% of adults aged 40 years or older in the United States have experienced some form of vestibular dysfunction.
 
 ## What should you consider?
 
-Don't make animations, sliders, or rapid movement start automatically. Give an indicator of what movement will happen on the site when a user takes action. Allow the user the option to turn off any animation and movement.
+Don't make animations, sliders, or rapid movement start automatically. Give an indicator of what movement will happen on the site when a user takes action. Allow the user the option to turn off any animation and movement at any point in the process.
 
 ## Additional reading
 - [Designing Safer Web Animation For Motion Sensitivity](https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity) - by Val Head _September 8th, 2015_
+- [An Introduction to the Reduced Motion Media Query](https://css-tricks.com/introduction-reduced-motion-media-query/)
+- [Your Interactive Makes Me Sick - Source: An OpenNews project](https://source.opennews.org/articles/motion-sick/)
+- [	Designing Safer Web Animation For Motion Sensitivity · An A List Apart Article](https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity)


### PR DESCRIPTION
This PR addresses https://github.com/a11yproject/a11yproject.com/issues/669

It has minor copy tweaks to standardize the lede paragraph, some slight tone shifting, and adds more additional reading content.

I wasn't able to preview this locally, there's some strange bug where some content is repeating itself locally on the index page, only with the capitalization removed (see https://github.com/a11yproject/a11yproject.com/pull/696), and the posts themselves aren't updating. Throwing away the local build and rebuilding it didn't seem to work, either.

Another thing: While "A primer to vestibular disorders" follows the "A primer to X" convention we're using, it should be "A primer on/for/about vestibular disorders". I'm hesitant to update the title without having some sort of redirect in place, though.
