### PR TITLE
Further reading front matter

### DIFF
--- a/CONTENT_STYLE_GUIDE.md
+++ b/CONTENT_STYLE_GUIDE.md
@@ -23,7 +23,7 @@ A consistent writing style will help site content feel unified and aid with comp
     - [Profanity](#profanity)
     - [Multimedia](#multimedia)
     - [Spell-check](#spell-check)
-1. [Markdown](#)
+1. [Markdown](#markdown)
     - [Front matter](#front-matter)
     - [Line breaks](#line-breaks)
     - [Headings](#headings)
@@ -93,7 +93,7 @@ Try not to exceed a seventh grade reading level. Avoid unnecessary jargon and ex
 
 ### Capitalization
 
-- Avoid writing in all caps. Some assistive technologies will announce all cap words as individual letters. 
+- Avoid writing in all caps. Some assistive technologies will announce all cap words as individual letters.
 - Capitalize words in a hashtag (e.g. #ThisReadsWell).
 
 ### Concepts and terminology
@@ -250,7 +250,7 @@ Use a single newline to separate block-level content like headings, lists, image
 
 ### Inline HTML
 
-Use HTML only when Markdown cannot accurately describe your content. Use [relevant, semantic HTML elements](https://alistapart.com/article/conversational-semantics) and attributes. Examples of this would be: 
+Use HTML only when Markdown cannot accurately describe your content. Use [relevant, semantic HTML elements](https://alistapart.com/article/conversational-semantics) and attributes. Examples of this would be:
 
 - A video embed.
 - A definition list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Articles are written using [Markdown](#markdown), using a special formatting tec
 
 To get started writing an article, [create a feature branch](#important-branches) and create a new Markdown file in the [`_posts` directory](https://github.com/a11yproject/a11yproject.com/tree/gh-pages/_posts). The Markdown's file name should reflect the intended publishing date and the title of the article. For example, a post about accessible typography may have a filename along the lines of `2018-09-12-accessible-typography.md`
 
-Copying an existing post, then updating its filename and front matter to match your article can be an easy way to help ensure everything is formatted properly.
+Copying [our example post](https://github.com/a11yproject/a11yproject.com/blob/gh-pages/_posts/example-post.md), then updating its filename and front matter to match your article can be an easy way to help ensure everything is formatted properly.
 
 #### Submitting
 
@@ -157,9 +157,9 @@ Creating a descriptive [Issue](https://github.com/a11yproject/a11yproject.com/is
 
 Project maintainers may reject Pull Requests at their discretion.
 
-When submitting your Pull Request, please include the text "closes" or "fixes" and then the issue number.   
-For example:  
-> Fixes #101. 
+When submitting your Pull Request, please include the text "closes" or "fixes" and then the issue number.
+For example:
+> Fixes #101.
 This will help us automatically close the issue upon merging the Pull Request!
 
 ### Stale Issues and Pull Requests

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,6 +32,29 @@ layout: default
 
   {{ content }}
 
+  {% if page.further_reading %}
+    <section id="further_reading">
+      <h2>Further reading</h2>
+      <ul>
+        {% for article in page.further_reading %}
+          {% if article.url && article.title %}
+            <li>
+              <a href="{{ article.url }}">{{ article.title }}</a>
+              {% if article.source %}
+                - {{ article.source }}
+              {% endif %}
+              {% if article.year %}
+                <time datetime="{{ article.year }}">
+                  ({{ article.year }})
+                </time>
+              {% endif %}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
   {%if page.path %}
     <a class="button-edit" href="//github.com/a11yproject/a11yproject.com/tree/gh-pages/{{ page.path }}">
       <svg class="icon" style="height:1em; width: 1em;"><use xlink:href="#icon-github"></use></svg>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,7 +37,7 @@ layout: default
       <h2>Further reading</h2>
       <ul>
         {% for article in page.further_reading %}
-          {% if article.url && article.title %}
+          {% if article.url and article.title %}
             <li>
               <a href="{{ article.url }}">{{ article.title }}</a>
               {% if article.source %}

--- a/_posts/2018-11-21-large-touch-targets.md
+++ b/_posts/2018-11-21-large-touch-targets.md
@@ -6,6 +6,33 @@ author: eric_bailey
 published: true
 categories:
   - Quick Tests
+further_reading:
+  - url: https://webplatform.github.io/docs/tutorials/understanding-css-units/#On-CSS-pixels,-physical-units-and-scalability
+    title: "Understanding pixels and other CSS units: On CSS pixels, physical units and scalability"
+    source: WebPlatform
+  - url: https://knowbility.org/blog/2018/WCAG21-255TargetSize/
+    title: "Exploring WCAG 2.1 — 2.5.5 Target Size"
+    source: Knowbility
+    year: 2018
+  - url: https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/
+    title: "Finger-Friendly Design: Ideal Mobile Touchscreen Target Sizes"
+    source: Smashing Magazine
+    year: 2012
+  - url: https://developers.google.com/web/tools/chrome-devtools/inspect-styles#examine_and_edit_box_model_parameters
+    title: "Inspect and Edit Pages and Styles: Examine and edit box model parameters"
+    source: Google Developers
+    year: 2018
+  - url: https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_computed_CSS
+    title: "Examine and edit CSS: Examine computed CSS - Firefox Developer Tools"
+    source: MDN
+    year: 2018
+  - url: https://support.apple.com/guide/safari-developer/view-the-computed-css-dev56fdc8177/mac
+    title: "View the computed CSS"
+    source: Apple Support
+  - url: https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide/elements/computed
+    title: "Microsoft Edge DevTools - Elements - Computed"
+    source: Microsoft Edge Development
+    year: 2017
 ---
 
 A touch target is the total area a user can click or tap on to activate an interactive element such as a link, input, or button.
@@ -40,13 +67,3 @@ If you right click on the interactive element you want to test, it will automati
 ![Chrome's inspector highlighting the height and width of Wikipedia's logo, which serves as a link back to the Wikipedia homepage. The logo's computed size is 160 by 160 CSS pixels. The inspector also has the code for the logo highlighted, as well as its computed properties. Screenshot.](/img/posts/2018-11-21-large-touch-targets/touch-target-inspector.png)
 
 The inspector also has a Computed panel. It will display the selected element's `height` and `width` values, as well as an alphabetical list of the other computed CSS properties. This can be good for checking how the browser ultimately renders your site's CSS.
-
-## Further reading
-
-- [Understanding pixels and other CSS units: On CSS pixels, physical units and scalability · WebPlatform Docs](https://webplatform.github.io/docs/tutorials/understanding-css-units/#On-CSS-pixels,-physical-units-and-scalability)
-- [Exploring WCAG 2.1 — 2.5.5 Target Size — Knowbility](https://knowbility.org/blog/2018/WCAG21-255TargetSize/)
-- [Finger-Friendly Design: Ideal Mobile Touchscreen Target Sizes — Smashing Magazine](https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/)
-- [Inspect and Edit Pages and Styles: Examine and edit box model parameters - Google Developers](https://developers.google.com/web/tools/chrome-devtools/inspect-styles#examine_and_edit_box_model_parameters)
-- [Examine and edit CSS: Examine computed CSS - Firefox Developer Tools - MDN](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_computed_CSS)
-- [View the computed CSS - Apple Support](https://support.apple.com/guide/safari-developer/view-the-computed-css-dev56fdc8177/mac)
-- [Microsoft Edge DevTools - Elements - Computed - Microsoft Edge Development](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide/elements/computed)

--- a/_posts/example-post.md
+++ b/_posts/example-post.md
@@ -15,20 +15,18 @@ further_reading:
     source: The A11y Project GitHub
 ---
 
-This is sample post file to get you started. Once you have a post ready to go, you can use this file as a jumping off
-point. Just make a copy of it in the same folder and rename it to: `yyyy-mm-dd-title-of-post`.
+This is sample post file to get you started. Once you have a post ready to go, you can use this file as a jumping off point. Just make a copy of it in the same folder and rename it to: `yyyy-mm-dd-title-of-post`.
 
 If this is your first post on The A11y Project site, please add your information to the /_data/authors.yml file.
 
-When you're done with your article, input all of the post specific details to the [Front Matter](https://jekyllrb.com/docs/front-matter/)
-of this file.
+When you're done with your article, input all of the post specific details to the [Front Matter](https://jekyllrb.com/docs/front-matter/) of this file.
 
 - `title`: The title of your post
 - `description`: A description of your post
-- `author`: The hash key of your author info in the authors.yml file
+- `author`: The key of your author info in the authors.yml file
 - `published`: Set published to true
 - `categories`: List of categories you think this post falls under
-- `further reading`: List of links sites with content to supplement your post
+- `further reading`: List of links to sites with content to supplement your post
     - `url`: The url of the link
     - `title`: Title of linked site
     - `source`: The name of the group, or author, who published the content

--- a/_posts/example-post.md
+++ b/_posts/example-post.md
@@ -3,7 +3,7 @@ layout: post
 title:
 description:
 author:
-published:
+published: false
 categories:
   - Category Name
 further_reading:

--- a/_posts/example-post.md
+++ b/_posts/example-post.md
@@ -1,11 +1,35 @@
 ---
 layout: post
-title:
+title: "example"
 description:
 author:
-published: false
+published: true
 categories:
   - Category Name
+further_reading:
+  - url: https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CONTRIBUTING.md#submitting-content
+    title: "The A11y Project Contributing guide: Submitting Content"
+    source: The A11y Project GitHub
+  - url: https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CONTENT_STYLE_GUIDE.md
+    title: "The A11y Project Content Style Guide"
+    source: The A11y Project GitHub
 ---
 
-This is sample post file to get you started. Once you have a post ready to go, you can use this file as a jumping off point. Just make a copy of it in the same folder and rename it. Then input the post specific details in the top section being sure to change `published` to `true`. 
+This is sample post file to get you started. Once you have a post ready to go, you can use this file as a jumping off
+point. Just make a copy of it in the same folder and rename it to: `yyyy-mm-dd-title-of-post`.
+
+If this is your first post on The A11y Project site, please add your information to the /_data/authors.yml file.
+
+When you're done with your article, input all of the post specific details to the [Front Matter](https://jekyllrb.com/docs/front-matter/)
+of this file.
+
+- `title`: The title of your post
+- `description`: A description of your post
+- `author`: The hash key of your author info in the authors.yml file
+- `published`: Set published to true
+- `categories`: List of categories you think this post falls under
+- `further reading`: List of links sites with content to supplement your post
+    - `url`: The url of the link
+    - `title`: Title of linked site
+    - `source`: The name of the group, or author, who published the content
+    - `year`: The year the content was authored

--- a/_posts/example-post.md
+++ b/_posts/example-post.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: "example"
+title:
 description:
 author:
-published: true
+published:
 categories:
   - Category Name
 further_reading:


### PR DESCRIPTION
Addresses Issue #697 

Making an initial PR for feedback on the generated HTML and format of the front matter property. I will go back and edit older posts with "further reading" sections in another PR, or, if preferred, additional commits on this PR.

Ended up going with: ```title as a link``` - ```source``` (```year```)

The other formats proposed in the comments on the Issue seemed too verbose when I actually generated them.

Screenshot of front matter generated further reading section on the ["Quick Test: Large Touch Targets" post](http://localhost:4000/posts/large-touch-targets/):
![image](https://user-images.githubusercontent.com/3345162/49679557-dce39f00-fa51-11e8-99af-7f0b3291f675.png)
