### PR TITLE
Adding a few folks from the React community to the follow page

### DIFF
--- a/_data/follow.yml
+++ b/_data/follow.yml
@@ -76,6 +76,9 @@
   - url: https://twitter.com/estellevw
     username: "@estellevw"
     name: "Estelle Weyl"
+  - url: https://twitter.com/beefancohen
+    username: "@beefancohen"
+    name: "Ethan Cohen"
   - url: https://twitter.com/goodwitch
     username: "@goodwitch"
     name: "Glenda Sims"
@@ -118,6 +121,9 @@
   - url: https://twitter.com/joedolson
     username: "@joedolson"
     name: "Joe Dolson"
+  - url: https://twitter.com/jkup
+    username: "@jkup"
+    name: "Jon Kuperman"
   - url: https://twitter.com/_josephwatkins
     username: "@_josephwatkins"
     name: "Joe Watkins"
@@ -139,6 +145,9 @@
   - url: https://twitter.com/wahlbin
     username: "@wahlbin"
     name: "Kathy Wahlbin"
+  - url: https://twitter.com/kentcdodds
+    username: "@kentcdodds"
+    name: "Kent C. Dodds"
   - url: https://twitter.com/LFLegal
     username: "@LFLegal"
     name: "Lainey Feingold"
@@ -208,6 +217,9 @@
   - url: https://twitter.com/russmaxdesign
     username: "@russmaxdesign"
     name: "Russ Weakley"
+  - url: https://twitter.com/ryanflorence
+    username: "@ryanflorence"
+    name: "Ryan Florence"
   - url: https://twitter.com/sarahtp
     username: "@sarahtp"
     name: "Sarah Pulis"
@@ -250,6 +262,9 @@
   - url: https://twitter.com/ted_drake
     username: "@ted_drake"
     name: "Ted Drake"
+  - url: https://twitter.com/todd
+    username: "@todd"
+    name: "Todd Kloots"
   - url: https://twitter.com/webinista
     username: "@webinista"
     name: "Tiffany Brown"


### PR DESCRIPTION
This PR adds a few folks from the React community who do a lot in the Accessibility space.

@evcohen - Created both the widely used eslint jsx-a11y plugin and an Accessibility plugin for Webpack.

@jkup (myself) - Teaches the Accessibility course on Front End Masters https://frontendmasters.com/courses/web-accessibility/.

@kentcdodds - Created Downshift, a primitive that allows you to build WAI-ARIA compliant React components.

@ryanflorence - Helped create both React Router and Reach Router (both have accessibility as a first class citizen) as well as a great educator in the a11y space!

@todd - Who has for years helped lead accessibility at Twitter and now Slack.

Thanks for the consideration!