### PR TITLE
minor: 'in line' should be styled 'inline'

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -147,7 +147,7 @@ permalink: checklist.html
 			<input name="unobtrusive-js-input" id="unobtrusive-js" aria-describedby="unobtrusive-js-description" type="checkbox">
 		</label>
 
-		<p id="unobtrusive-js-description" class="description">Use unobtrusive JavaScript (never use in line scripting).</p>
+		<p id="unobtrusive-js-description" class="description">Use unobtrusive JavaScript (never use inline scripting).</p>
 
 		<!-- js alts -->
 		<label for="alt-js" class="checkbox">No-JS Alternatives


### PR DESCRIPTION
This is the commonplace style - for example on MDN:

![image](https://user-images.githubusercontent.com/32314/53903769-68d97880-3ff9-11e9-9db9-010ece04622d.png)