### PR TITLE
Import jQuery script from cdnjs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -166,7 +166,7 @@
 
     </footer>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/garlic.js/1.2.2/garlic.min.js"></script>
     <script src="/js/jquery.waypoints.min.js"></script>
 


### PR DESCRIPTION
Really quick PR to suggest importing jQuery from [cdnjs](https://cdnjs.com/libraries/jquery/1.11.1) (FOSS) rather than Google.

Coherent with the move away from Google for privacy reasons (see #737, #768)

Tested locally.