### PR TITLE
Add guidelines for editing articles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,14 @@ Want to help? Here's how. Please be sure to check our [Content Style Guide](http
     - [Events](#events)
     - [Patterns](#patterns)
     - [Resources](#resources)
-    - [Promotions, partnership deals, and SEO scams](#promotions-partnership-seals-and-seo-scams)
+    - [Promotions, partnership deals, and SEO scams](#promotions-partnership-deals-and-seo-scams)
     - [Rejection](#rejection)
 1. [Fixing things](#fixing-things)
     - [Reporting Issues](#reporting-issues)
     - [Submitting Pull Requests](#submitting-pull-requests)
     - [Stale Issues and Pull Requests](#stale-issues-and-pull-requests)
     - [Labels](#labels)
+    - [Editing Articles](#editing-articles)
 1. [License](#license)
 
 
@@ -194,6 +195,14 @@ A Pull Request (PR) is considered to be in a "stale" state when the following co
 
 [Labels](https://github.com/a11yproject/a11yproject.com/labels) allow the project maintainers to quickly sort filter and site [Issues](#reporting-issues) and [Pull Requests](#submitting-pull-requests). They will be added and removed as needed.
 
+### Editing Articles
+
+When editing articles, leave the original publish date and author as-is. Add the following to the front matter:
+
+```
+updated_by: editor_name
+last_updated: 2019-##-##
+```
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Want to help? Here's how. Please be sure to check our [Content Style Guide](http
     - [Submitting Pull Requests](#submitting-pull-requests)
     - [Stale Issues and Pull Requests](#stale-issues-and-pull-requests)
     - [Labels](#labels)
-    - [Updating Articles](#editing-articles)
+    - [Updating Articles](#updating-articles)
 1. [License](#license)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Want to help? Here's how. Please be sure to check our [Content Style Guide](http
     - [Submitting Pull Requests](#submitting-pull-requests)
     - [Stale Issues and Pull Requests](#stale-issues-and-pull-requests)
     - [Labels](#labels)
-    - [Editing Articles](#editing-articles)
+    - [Updating Articles](#editing-articles)
 1. [License](#license)
 
 
@@ -195,9 +195,9 @@ A Pull Request (PR) is considered to be in a "stale" state when the following co
 
 [Labels](https://github.com/a11yproject/a11yproject.com/labels) allow the project maintainers to quickly sort filter and site [Issues](#reporting-issues) and [Pull Requests](#submitting-pull-requests). They will be added and removed as needed.
 
-### Editing Articles
+### Updating Articles
 
-When editing articles, leave the original publish date and author as-is. Add the following to the front matter:
+When updating articles, leave the original publish date and author as-is. Add the following to the front matter:
 
 ```
 updated_by: editor_name


### PR DESCRIPTION
As discussed in #771, this is how we currently handle crediting editors. I wanted to add this to contrib guidelines so it could be more easily found.

Also, there was a small typo in one of the TOC anchor links.