### PR TITLE
Fixing the post title to be more accurate 

### DIFF
--- a/_posts/2013-04-21-myth-screen-readers-dont-use-javascript.md
+++ b/_posts/2013-04-21-myth-screen-readers-dont-use-javascript.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Myth: Screen reader users don't use Javascript"
+title: "Myth: Screen reader users don't use JavaScript"
 description: "97.6% of all screen readers have JavaScript enabled."
 author: dave_rupert
 last_updated: 2014-09-26


### PR DESCRIPTION
This PR fixes the issue  #785. I am updating the title of the post from "Myth: Screen Reader don't use JavaScript" to "Myth: Screen reader users don't use Javascript"