### PR TITLE
Add redirect functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem 'github-pages', group: :jekyll_plugins
 group :development, :test do
   gem 'rake'
   gem 'html-proofer'
+  gem 'jekyll-redirect-from'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,4 @@ gem 'github-pages', group: :jekyll_plugins
 group :development, :test do
   gem 'rake'
   gem 'html-proofer'
-  gem 'jekyll-redirect-from'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -31,8 +31,9 @@ google_analytics:
 #   id: disqusid
 
 plugins:
-  - jekyll-sitemap
   - jekyll-feed
+  - jekyll-redirect-from
+  - jekyll-sitemap
 
 feed:
   path: atom.xml

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,6 @@ google_analytics:
 
 plugins:
   - jekyll-feed
-  - jekyll-redirect-from
   - jekyll-sitemap
 
 feed:

--- a/_posts/2013-04-21-people-who-use-screen-readers-dont-use-javascript.md
+++ b/_posts/2013-04-21-people-who-use-screen-readers-dont-use-javascript.md
@@ -1,11 +1,13 @@
 ---
 layout: post
-title: "Myth: Screen reader users don't use JavaScript"
+title: "Myth: People who use screen readers don't use JavaScript"
 description: "97.6% of all screen readers have JavaScript enabled."
 author: dave_rupert
 last_updated: 2014-09-26
 categories:
   - Myths
+redirect_from:
+  - /posts/2013-04-21-myth-screen-readers-dont-use-javascript
 further_reading:
   - url: https://www.w3.org/TR/WCAG20-TECHS/client-side-script.html
     title: "Client-side Scripting Techniques for WCAG 2.0"


### PR DESCRIPTION
This PR adds a gem to allow for redirects, as post filenames should reflect the title in their frontmatter.

I have also updated the title on an article to [adhere to our content styleguide's rules about the word "user"](https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CONTENT_STYLE_GUIDE.md#user-or-person).