### PR TITLE
Incorporate the CoC into the footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -157,8 +157,9 @@
 
           <p class="notice">Notice an issue or want to help? <a href="https://github.com/a11yproject/a11yproject.com">Please contribute</a>.</p>
           <p style="margin-bottom: 0;">&copy; <span class="a11y-copyright"></span> The Accessibility Project</p>
-          <p style="margin-bottom: 0;">Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a></p>
-          <p><a href="purpose.html">Our purpose</a></p>
+          <p>Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a></p>
+          <p style="margin-bottom: 0;"><a href="purpose.html">Our purpose</a></p>
+          <p><a href="https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CODE_OF_CONDUCT.md#the-a11y-project-code-of-conduct">Code of Conduct</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
This PR adds a link to our Code of Conduct on GitHub to our global site footer.