### PR TITLE
Fix "Our Purpose" link in footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -155,7 +155,7 @@
           <p class="notice">Notice an issue or want to help? <a href="https://github.com/a11yproject/a11yproject.com">Please contribute</a>.</p>
           <p class="no-lead">&copy; <span class="a11y-copyright"></span> The Accessibility Project</p>
           <p>Powered by <a href="https://github.com/mojombo/jekyll">Jekyll</a></p>
-          <p class="no-lead"><a href="purpose.html">Our purpose</a></p>
+          <p class="no-lead"><a href="/purpose.html">Our purpose</a></p>
           <p><a href="https://github.com/a11yproject/a11yproject.com/blob/gh-pages/CODE_OF_CONDUCT.md#the-a11y-project-code-of-conduct">Code of Conduct</a></p>
         </div>
       </div>


### PR DESCRIPTION
Link is redirecting to the wrong place when not at the site root.