### PR TITLE
Makes code block syntax highlighting consistent

### DIFF
--- a/_posts/2013-01-11-how-to-hide-content.md
+++ b/_posts/2013-01-11-how-to-hide-content.md
@@ -19,22 +19,26 @@ Developers commonly use `display: none` to hide content on the page. Unfortunate
 
 There are real world situations where you might need to hide elements visually (e.g., a form `label`), but keep the element text available to be announced by a screen reader. The "clip pattern" accomplishes this task for you; hide the content visually, yet provide the content to screen readers. Unlike CSS positioning and negative text-indent techniques, the "clip pattern" also works with RTL (Right-to-left) languages for localization. See the article *[Hiding Content for Accessibility](https://snook.ca/archives/html_and_css/hiding-content-for-accessibility)* for more information on the visually-hidden pattern.
 
-    .visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-        position: absolute !important;
-        height: 1px; width: 1px;
-        overflow: hidden;
-        clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-        clip: rect(1px, 1px, 1px, 1px);
-    }
+```css
+.visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+    position: absolute !important;
+    height: 1px; width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+}
+```
 
 It is possible to apply the `.visually-hidden` class to content that contains natively focusable elements (such as `a`, `button`, `input`, etc). It's important to show these elements visually when they receive focus, otherwise a keyboard-only user might not know which element currently has focus. CSS for this might look something like:
 
-    .visually-hidden a:focus,
-    .visually-hidden input:focus,
-    .visually-hidden button:focus {
-        position:static;
-        width:auto; height:auto;
-    }
+```css
+.visually-hidden a:focus,
+.visually-hidden input:focus,
+.visually-hidden button:focus {
+    position:static;
+    width:auto; height:auto;
+}
+```
 
 Consider adding these HTML classes and CSS rules to your base stylesheet and use them when applicable.
 
@@ -44,10 +48,14 @@ The `aria-hidden="true"` HTML attribute is the logical opposite of the `.visuall
 
 There may be cases where you want to use `aria-hidden` and also visually hide the content. This can be accomplished with some CSS like:
 
-    .my-component[aria-hidden="true"] {
-        display: none;
-    }
+```css
+.my-component[aria-hidden="true"] {
+    display: none;
+}
+```
 
  Another way to hide content both visually and from assistive technology is the [HTML5 `hidden` attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). To support older browsers like IE9, you might want to add the following css to your pages:
 
-     [hidden] { display: none; }
+```css
+[hidden] { display: none; }
+```

--- a/_posts/2013-01-14-aria-landmark-roles.md
+++ b/_posts/2013-01-14-aria-landmark-roles.md
@@ -65,7 +65,8 @@ The following are common landmark roles that tend to be useful on many pages:
 </dl>
 
 Implementing landmarks in your documents is a straight forward process. Simply add the <code>role</code> attribute referencing the appropriate landmark value. For example:
-```
+
+```html
 <footer role="contentinfo">...</footer>
 ```
 
@@ -73,7 +74,7 @@ Implementing landmarks in your documents is a straight forward process. Simply a
 ## HTML5 implicit mappings of Landmark roles
 Before you start adding <abbr>ARIA</abbr> roles to your HTML elements, you should be aware that many of these landmarks will be natively conveyed by proper HTML usage. For example, the following markup snippet will produce a warning in modern HTML and accessibility automated checkers:
 
-```
+```html
 <header role="banner" class="site-header">...</header>
 ```
 

--- a/_posts/2013-01-14-never-use-maximum-scale.md
+++ b/_posts/2013-01-14-never-use-maximum-scale.md
@@ -18,13 +18,13 @@ By setting `maximum-scale=1.0`, you are disabling the functionality to use pinch
 
 ### The bad way:
 
-``` html
+```html
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 ```
 
 ### The good way:
 
-``` html
+```html
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 ```
 

--- a/_posts/2013-04-22-title-attributes.md
+++ b/_posts/2013-04-22-title-attributes.md
@@ -39,7 +39,7 @@ Based on the intended behavior for Text Alternative Computation the precedence f
 
 In cases where two or more of the above are used, whatever is highest in that list becomes what gets used. Consider the following example:
 
-```
+```html
 <img src="/path/to/image.png" alt="" title="some stuff that could be useful" />
 ```
 

--- a/_posts/2013-05-11-skip-nav-links.md
+++ b/_posts/2013-05-11-skip-nav-links.md
@@ -17,7 +17,7 @@ Skip nav links are useful for users who use keyboard navigation only, but screen
 
 ### Example
 
-{% highlight html %}
+```html
 <body>
   <a href="#main">Skip to main content</a>
   <nav role="navigation">
@@ -31,7 +31,7 @@ Skip nav links are useful for users who use keyboard navigation only, but screen
     <!-- page specific content -->
   </main>
 </body>
-{% endhighlight %}
+```
 
 **Disclaimer**: The mechanism by which skip navigation links work had for some time been broken in Webkit based browsers and has only [recently been fixed](https://code.google.com/p/chromium/issues/detail?id=37721). Until these browsers release the fixes, you may need to use a JavaScript polyfill to make skip nav links work.
 

--- a/_posts/2013-05-15-understanding-vestibular-disorders.md
+++ b/_posts/2013-05-15-understanding-vestibular-disorders.md
@@ -35,7 +35,7 @@ Don't make animations, sliders, videos, or rapid movement start automatically. G
 
 Also, with the CSS [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query you can write conditional CSS animations and transitions based on the user's preference exposed from the browser settings. For example, you can disable all animations and transitions for users who explicitly prefers reduced motion:
 
-```
+```css
 img {
   animation: slidein 3s;
 }
@@ -55,7 +55,7 @@ button {
 }
 
 button:focus,
-button:hover { 
+button:hover {
   transform: rotate(360deg);
 }
 
@@ -68,7 +68,7 @@ button:hover {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001s !important;
   }
-  
+
 }
 ```
 

--- a/_posts/2013-07-17-using-caption-services-with-html5-video.md
+++ b/_posts/2013-07-17-using-caption-services-with-html5-video.md
@@ -27,12 +27,14 @@ In addition to making video accessible to those with hearing issues, having a tr
 
 So how do we pull off putting captions into a video after the video has been produced? Fortunately, the video element has a solution for us. We have to provide a transcript file as a track element after the video source files.
 
-    <video class="span12 readable" poster="your-video-poster.jpg" controls title="My Movie">
-        <source  src="your-video.m4v" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
-        <source  src="your-video.ogg" type='application/ogg' />
-        <source  src="your-video.webm" type='video/webm' />
-        <track src="your-video-transcript.vtt" label="English Captions" kind="subtitles" srclang="en-us" default />
-    </video>
+```html
+<video class="span12 readable" poster="your-video-poster.jpg" controls title="My Movie">
+    <source  src="your-video.m4v" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
+    <source  src="your-video.ogg" type='application/ogg' />
+    <source  src="your-video.webm" type='video/webm' />
+    <track src="your-video-transcript.vtt" label="English Captions" kind="subtitles" srclang="en-us" default />
+</video>
+```
 
 Many frameworks built on top of the video element make it even simpler to add in captions, like [Video.js](https://videojs.com/).
 
@@ -63,19 +65,21 @@ In addition to the VTT file format, you can also use TTML (Time Text Markup Lang
 
 TTML files look a bit more complex:
 
-    <tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
-        <body>
-            <div>
-                <p begin="00:00:9.00" end="00:00:11.00">
-                    Alice: Curiouser and curiouser.
-                </p>
+```xml
+<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+    <body>
+        <div>
+            <p begin="00:00:9.00" end="00:00:11.00">
+                Alice: Curiouser and curiouser.
+            </p>
 
-                <p begin="00:00:17:00" end="00:00:18:00">
-                    Rabbit: I told you she was the right Alice!
-                </p>
-            </div>
-        </body>
-    </tt>
+            <p begin="00:00:17:00" end="00:00:18:00">
+                Rabbit: I told you she was the right Alice!
+            </p>
+        </div>
+    </body>
+</tt>
+```
 
 You may also see captions in formats like `.srt` or others that may work best for your needs.
 

--- a/_posts/2014-05-15-getting-started-aria.md
+++ b/_posts/2014-05-15-getting-started-aria.md
@@ -65,43 +65,43 @@ To create accessible applications, basic principles of semantic HTML, keyboard s
 * Landmark role
   The `<nav>` element implicitly has a landmark role of `navigation` allowing screen reader users to navigate directly to this element. Review the article [Quick Tip: Aria Landmark Roles and HTML5 Implicit Mapping](https://a11yproject.com/posts/aria-landmark-roles/) for more information.
 
-~~~~~~~~
-    <nav>
-      <ul>
-        <li>
-          <a href="/">Home</a>
-        </li>
-        <li>
-          <a href="/contact">Contact Page</a>
-        </li>
-      </ul>
-    </nav>
-~~~~~~~~
+  ```html
+  <nav>
+    <ul>
+      <li>
+        <a href="/">Home</a>
+      </li>
+      <li>
+        <a href="/contact">Contact Page</a>
+      </li>
+    </ul>
+  </nav>
+  ```
 
 * aria-labelledby
 
-~~~~~~~~
-<section aria-labelledby="KittensHeader">
-  <h2 id="KittensHeader">All Abbout Kittens</h2>
-  <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>
-</section>
-~~~~~~~~
+  ```html
+  <section aria-labelledby="KittensHeader">
+    <h2 id="KittensHeader">All Abbout Kittens</h2>
+    <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>
+  </section>
+  ```
 
   The `<section>` element includes the ARIA property `aria-labelledby` which lists the ID of the section title. Screen readers will announce this title when they reach the `<section>` element, giving users a sense of the content contained in this portion.
 
 * Role, state, and property together in a Tab control
 
-~~~~~~~~
-<ul role="tablist">
-  <li>
-    <a href="#first-tab" role="tab" aria-selected="true" aria-controls="first-tab">Panel 1</a>
-  </li>
-  <li>
-    <a href="#second-tab" role="tab" aria-selected="false" aria-controls="second-tab">Panel 2</a>
-  </li>
-</ul>
-<div id="first-tab" role="tabpanel"></div>
-<div id="second-tab" role="tabpanel"></div>
-~~~~~~~~
+  ```html
+  <ul role="tablist">
+    <li>
+      <a href="#first-tab" role="tab" aria-selected="true" aria-controls="first-tab">Panel 1</a>
+    </li>
+    <li>
+      <a href="#second-tab" role="tab" aria-selected="false" aria-controls="second-tab">Panel 2</a>
+    </li>
+  </ul>
+  <div id="first-tab" role="tabpanel"></div>
+  <div id="second-tab" role="tabpanel"></div>
+  ```
 
   Each element has an ARIA role and attributes to create a complete tab widget. The relationship between a tab link and tab panel is now available to screen readers.

--- a/_posts/2016-01-07-placeholder-input-elements.md
+++ b/_posts/2016-01-07-placeholder-input-elements.md
@@ -38,7 +38,7 @@ Make your forms accessible by using one of the following methods (in order of pr
 
 While we're paying attention to our placeholder text, let's review how to add better contrast:
 
-{% highlight css %}
+```css
 ::-webkit-input-placeholder {
   color: #626262;
 }
@@ -51,7 +51,7 @@ While we're paying attention to our placeholder text, let's review how to add be
 :-ms-input-placeholder {
   color: #626262;
 }
-{% endhighlight %}
+```
 
 The above CSS assumes that the background for the form controls are `#fff`. If we test `#fff` and `#626262` in a color contrast tool like [Tanaguru Contrast-Finder](http://contrast-finder.tanaguru.com/result.html;jsessionid=57DFFB6E8E217E7C92C55B7CE2629CF6?foreground=%23626262&background=%23ffffff&isBackgroundTested=false&ratio=4.5&algo=HSV), the results will approve these colors for valid contrast. You can use your own color for this, but be sure to read about [how conformance levels work](https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html#uc-levels-head), and use a color contrast tool to confirm.
 
@@ -60,7 +60,8 @@ In the above CSS, each selector for placeholder text needs to be seperate in the
 Once we have sufficient color contrast in our placeholders, placeholders can be used in addition to labels. Here are two examples of forms where placeholders are used with labels to maintain accessibility.
 
 **Explicit labeling:**
-{% highlight html %}
+
+```html
 <form>
   <label for="your-name">
     Your Name:
@@ -68,10 +69,11 @@ Once we have sufficient color contrast in our placeholders, placeholders can be 
   <input type="text" id="your-name" name="your-name" placeholder="What's your name?">
   <input type="submit" value="Submit Name">
 </form>
-{% endhighlight %}
+```
 
 **Implicit & explicit labeling combined:**
-{% highlight html %}
+
+```html
 <form>
   <label for="your-name">
     Your Name:
@@ -79,6 +81,6 @@ Once we have sufficient color contrast in our placeholders, placeholders can be 
   </label>
   <input type="submit" value="Submit Name">
 </form>
-{% endhighlight %}
+```
 
 Note that in the second example above, omitting the `for` attribute on the label is still valid, but still best practice to include. By keeping the `for` attribute in place, we're combining both explicit and implicit techniques. For more about explicit and implicit labeling, check out ["Labeled with Love"](https://www.aaron-gustafson.com/notebook/labeled-with-love/). By adding the `for` attribute to a label with the same value as the ID for the input element it corresponds to, the label becomes *explicitly* associated with that input element. Explicit labeling is great for screen reader users and when clicking/focusing that label, it will automatically focus the associated input element.

--- a/_posts/2016-03-05-accessible-data-tables.md
+++ b/_posts/2016-03-05-accessible-data-tables.md
@@ -11,7 +11,8 @@ categories:
 The semantic purpose of a data table is to present tabular data. Sighted users can quickly scan the table but a screen reader goes through line by line. Proper markup must be added to help the screen reader make the correct associations that a sighted user would.
 
 ## Example of an accessible data table.
-{% highlight html %}
+
+```html
 <table>
     <caption>Monthly Budget</caption>
     <thead>
@@ -37,7 +38,7 @@ The semantic purpose of a data table is to present tabular data. Sighted users c
         </tr>
     </tbody>
 </table>
-{% endhighlight %}
+```
 
 Making an accessible table isn’t hard and can be broken down into two main things.
 


### PR DESCRIPTION
Fixes #825. 

## Before

<img width="764" alt="Screen Shot 2019-07-28 at 12 11 35 AM" src="https://user-images.githubusercontent.com/1214020/62002142-50631b00-b0cc-11e9-9226-e64f458a6012.png">

## After

<img width="725" alt="Screen Shot 2019-07-28 at 12 11 42 AM" src="https://user-images.githubusercontent.com/1214020/62002146-5658fc00-b0cc-11e9-86a0-fd7405b1c8ee.png">
