### PR TITLE
Fixes #833: Fix broken Checklist documentation link

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -959,7 +959,7 @@ redirect_from:
       </summary>
       <div class="checklist-details">
         <p class="checklist-criterion">
-          <a href="http://localhost:4000/AA%20requires%20contrast%20ratio%20of%203.0:1.">1.4.11 Non-text Contrast</a>
+          <a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">1.4.11 Non-text Contrast</a>
         </p>
         <p class="checklist-description">
           Level <strong>AA</strong> compliance requires a contrast ratio of <code>3.0:1</code>.


### PR DESCRIPTION
This pull request addresses issue #833

The documentation link under _"Check the contrast for all icons."_ linked to a
`localhost` address. This commit updates the link to point to the appropriate
location on the W3C website.

Fixes #833