### PR TITLE
Fixes #837

### DIFF
--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -22,7 +22,7 @@ layout: default
         <a class="btn" href="/about">Learn more</a>
       </li>
       <li>
-        <a  class="btn"  href="http://github.com/a11yproject/a11yproject.com">Contribute on Github</a>
+        <a class="btn" href="https://github.com/a11yproject/a11yproject.com/blob/gh-pages/README.md">Contribute on Github</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
As per the discussion in #837, I changed the contribute link to point to README.md instead of the base github page, and got rid of extra spaces around the class attribute.