### PR TITLE
🔧 Fix typo: "locationso"

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -200,7 +200,7 @@ redirect_from:
           <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html">2.4.3 Focus Order</a>
         </p>
         <p class="checklist-description">
-          People who are blind or who have low vision may be disoriented when focus is moved without their permission. Additionally, <code>autofocus</code> can be problematic for people with motor control disabilities, as it may create extra work for them to navigate out from the autofocused area and to other locationso on the page/view.
+          People who are blind or who have low vision may be disoriented when focus is moved without their permission. Additionally, <code>autofocus</code> can be problematic for people with motor control disabilities, as it may create extra work for them to navigate out from the autofocused area and to other locations on the page/view.
         </p>
       </div>
     </details>


### PR DESCRIPTION
Noticed a typo under the section of the checklist about `autoFocus` and decided to fix it.