### PR TITLE
Closes #906 - duplicate id in code example for aria-controls

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -33,6 +33,9 @@ greg_tarnoff:
 guilherme_simoes:
   name: Guilherme Simões
   contact: https://guilhermesimoes.github.io
+kameron_ahler:
+  name: Kameron Ahler
+  contact: https://github.com/kameronahler
 mat_marquis:
   name: Mat Marquis
   contact: https://twitter.com/wilto

--- a/_posts/2014-05-15-getting-started-aria.md
+++ b/_posts/2014-05-15-getting-started-aria.md
@@ -4,8 +4,8 @@ title: "Getting started with ARIA"
 description: "Introduction to ARIA, describing Roles, States, and Properties and when to use ARIA in HTML."
 published: true
 author: monika_piotrowicz
-updated_by: scott_ohara
-last_updated: 2019-10-24
+updated_by: kameron_ahler
+last_updated: 2020-03-14
 categories:
   - Background
 ---
@@ -96,7 +96,7 @@ To create accessible applications, basic principles of semantic HTML, keyboard s
     <button role="tab" aria-selected="false" aria-controls="panel_2" tabindex="-1">Oranges</button>
   </div>
   <div id="panel_1" aria-label="Apples" role="tabpanel" tabindex="0">...</div>
-  <div id="panel_1" aria-label="Oranges" role="tabpanel" hidden>...</div>
+  <div id="panel_2" aria-label="Oranges" role="tabpanel" hidden>...</div>
   ```
 
   Each element has an ARIA role and attributes to create a complete Tab Widget.  Note: as of June 2019 no screen readers support `aria-controls` by default.


### PR DESCRIPTION
Closes #906 

## Problem Summary
The final code example in the [Getting Started with ARIA article](https://github.com/a11yproject/a11yproject.com/blob/gh-pages/_posts/2014-05-15-getting-started-aria.md) has two elements with unique `aria-controls` values, but the corresponding elements with `role="tabpanel"` have matching `id` values.

## Changes
- change duplicate `id` to match second `aria-controls` element in code example
- update `authors.yml` per documentation