### PR TITLE
Add Netlify attribution

### DIFF
--- a/src/_includes/nav/copyright-back-to-top.njk
+++ b/src/_includes/nav/copyright-back-to-top.njk
@@ -1,5 +1,5 @@
 <p class="l-footer__copyright c-footer__copyright">
-  &copy; 2013–2020 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. Powered by <a class="c-footer__copyright-link" href="https://www.11ty.io/">Eleventy</a>.
+  &copy; 2013–2020 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. Powered by <a class="c-footer__copyright-link" href="https://www.11ty.io/">Eleventy</a> and <a class="c-footer__copyright-link" href="https://www.11ty.io/">Netlify</a>.
 </p>
 <p class="l-footer__top c-footer__top">
   <a class="c-footer__copyright-link" href="#header">Back to top</a>

--- a/src/_includes/nav/copyright-back-to-top.njk
+++ b/src/_includes/nav/copyright-back-to-top.njk
@@ -1,5 +1,5 @@
 <p class="l-footer__copyright c-footer__copyright">
-  &copy; 2013–2020 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. Powered by <a class="c-footer__copyright-link" href="https://www.11ty.io/">Eleventy</a> and <a class="c-footer__copyright-link" href="https://www.11ty.io/">Netlify</a>.
+  &copy; 2013–2020 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. Powered by <a class="c-footer__copyright-link" href="https://www.11ty.io/">Eleventy</a> and <a class="c-footer__copyright-link" href="https://www.netlify.com/">Netlify</a>.
 </p>
 <p class="l-footer__top c-footer__top">
   <a class="c-footer__copyright-link" href="#header">Back to top</a>


### PR DESCRIPTION
This PR adds a link to Netlify, as per their [Open Source Plan Policy](https://www.netlify.com/legal/open-source-policy/).