### PR TITLE
Update branch name

### DIFF
--- a/src/contributing-guidelines.njk
+++ b/src/contributing-guidelines.njk
@@ -74,7 +74,7 @@ templateClass: template-generic
 		<code>main</code> is the <a href="https://www.atlassian.com/git/tutorials/using-branches">production branch</a>. This is the live website.
 	</p>
 	<p>
-		If you have a feature request, we suggest first <a href="https://github.com/a11yproject/a11yproject.com/issues/new">filing an Issue</a> to discuss it (please read <a href="#reporting-issues">how to report an issue first</a>). Once that feature has been approved you can start coding! Create a new <a href="https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow">feature branch</a> from <code>gh-pages</code>, and name it something that references the feature you&#39;ll be working on. For example a feature to increase the site&#39;s type size could be: <code>increase-font-size</code>.
+		If you have a feature request, we suggest first <a href="https://github.com/a11yproject/a11yproject.com/issues/new">filing an Issue</a> to discuss it (please read <a href="#reporting-issues">how to report an issue first</a>). Once that feature has been approved you can start coding! Create a new <a href="https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow">feature branch</a> from <code>main</code>, and name it something that references the feature you&#39;ll be working on. For example a feature to increase the site&#39;s type size could be: <code>increase-font-size</code>.
 	</p>
 	<p>
 		A list of <a href="https://github.com/a11yproject/a11yproject.com/branches">all active branches is available</a>.


### PR DESCRIPTION
The contributing guidelines reference the `gh-pages` branch.  Should it be a mistake, this PR updates the guidelines to reference `main` instead.

Closes #971 