### PR TITLE
Fix #980: Update link paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,53 +2,53 @@
 
 # The A11Y Project
 
-The Accessibility [(A11Y)](numeronyms) Project is an Open-source, community-driven effort to make digital accessibility easier.
+The Accessibility [(A11Y)](https://a11yproject.com/posts/a11y-and-other-numeronyms/) Project is an Open-source, community-driven effort to make digital accessibility easier.
 
 
 ## Contributing
 
-You can learn about helping this project by reading our [Code of Conduct](coc), [Contributor documentation](contributing-guidelines), and [Content Style Guide](content-style-guide). Please familiarize yourself with them before submitting content.
+You can learn about helping this project by reading our [Code of Conduct](https://a11yproject.com/code-of-conduct/), [Contributor documentation](https://a11yproject.com/contributing-guidelines/), and [Content Style Guide](https://a11yproject.com/content-style-guide/). Please familiarize yourself with them before submitting content.
 
-This `README` is focused on the technical side of the project. If you are interested in contributing information like Posts or Resources, please refer to our [Contributing Guidelines](contributing-guidelines).
+This `README` is focused on the technical side of the project. If you are interested in contributing information like Posts or Resources, please refer to our [Contributing Guidelines](https://a11yproject.com/contributing-guidelines/).
 
 
 ## Development
 
 ### Technology
 
-The A11Y Project uses [Eleventy](11ty) to manage its content. Eleventy relies on [Markdown](markdown), [Sass](sass), [Nunjucks](nunjucks), and [JSON](json) to function.
+The A11Y Project uses [Eleventy](https://www.11ty.io/) to manage its content. Eleventy relies on [Markdown](https://daringfireball.net/projects/markdown/syntax), [Sass](https://sass-lang.com/), [Nunjucks](https://mozilla.github.io/nunjucks/), and [JSON](https://www.json.org/) to function.
 
-It may be helpful to familiarize yourself with these technologies, depending on what you want to do. For more information, check our our [Contributor documentation](contributing-guidelines).
+It may be helpful to familiarize yourself with these technologies, depending on what you want to do. For more information, check our our [Contributor documentation](https://a11yproject.com/contributing-guidelines/).
 
 ### Requirements
 
 You'll need access to the following programs and technology in order to get the website running on your computer to work on:
 
 1. A command line application such as Terminal.
-    - If you want to learn more about working in the command line, Wes Bos offers [a great free course](terminal).
-    - If you are using Windows, [Hyper](hyper) is a good, free command-line application you can download, install, and run.
-1. [Git](git) version control and a [GitHub account](github).
+    - If you want to learn more about working in the command line, Wes Bos offers [a great free course](https://commandlinepoweruser.com/).
+    - If you are using Windows, [Hyper](https://hyper.is/) is a good, free command-line application you can download, install, and run.
+1. [Git](https://git-scm.com/) version control and a [GitHub account](https://github.com/).
     - You can check to see if Git is already installed on your computer by typing `git --version` into your command line application. If it is installed it will list the currently installed version (e.g. `git version 2.18.0`).
-    - If you prefer to use a GUI to work with version control, GitHub offers a [free desktop app](github-app).
-1. [Node.js](node), a programming environment powered by JavaScript.
+    - If you prefer to use a GUI to work with version control, GitHub offers a [free desktop app](https://desktop.github.com).
+1. [Node.js](https://nodejs.org/en/), a programming environment powered by JavaScript.
     - You can check to see if Node.js is already installed on your computer by typing `node -v` into your command line application. If it is installed it will list the currently installed version (e.g. `v10.2.1`). The A11Y Project requires a minimum version of `10.14.2`.
-    - It may also be helpful to use a program such as [nvm](nvm) to help manage your Node.js versions. This will ensure that the version of Node.js your computer uses to run various things won't conflict with an updated version.
+    - It may also be helpful to use a program such as [nvm](https://github.com/creationix/nvm) to help manage your Node.js versions. This will ensure that the version of Node.js your computer uses to run various things won't conflict with an updated version.
 
 ### Installation
 
 Once you have met [the prerequisites](#requirements), follow these steps to install the website on your computer:
 
 1. Clone this repository by entering this command into your command line application: ` git clone https://github.com/a11yproject/a11yproject.com.git`. It will create a version controlled copy of the website in the directory you entered the command in.
-1. Navigate into the project's [root directory](root) by typing `cd a11yproject.com` in your command line application.
+1. Navigate into the project's [root directory](https://en.m.wikipedia.org/wiki/Root_directory) by typing `cd a11yproject.com` in your command line application.
 1. Install the project's Node.js modules by typing `npm install` into your command line application. A list of these modules should be displayed after they are downloaded and installed.
 
 ### Running the website
 
 After cloning and installing project Node.js modules, type `npm run a11yproject` into your command line application. This will tell Node.js to compile the project and turn it into a website.
 
-Your command line application will then display some information about Jekyll, including a line that starts with `Local:`. You can copy the URL it points to (it should read something like [`http://localhost:3000`](localhost)) and paste it into a browser tab. This will load a local copy of the website that you can interact with to preview your changes.
+Your command line application will then display some information about Jekyll, including a line that starts with `Local:`. You can copy the URL it points to (it should read something like [`http://localhost:3000`](http://localhost:3000)) and paste it into a browser tab. This will load a local copy of the website that you can interact with to preview your changes.
 
-You can also use the `External` URL to preview the local copy on another device connected to the same network, which helps you check to see how the site looks and functions on things like smartphones. This is done via [Browsersync](browsersync).
+You can also use the `External` URL to preview the local copy on another device connected to the same network, which helps you check to see how the site looks and functions on things like smartphones. This is done via [Browsersync](https://www.browsersync.io/).
 
 ### Updating the website
 
@@ -62,7 +62,7 @@ You can tell Node.js to stop running by pressing the <kbd>Control</kbd> and <kbd
 
 ### Code Tour
 
-If you use [Visual Studio Code](vscode) as your code editor, you can take an introductory tour of the repository via the [CodeTour extension](codetour).
+If you use [Visual Studio Code](https://code.visualstudio.com/) as your code editor, you can take an introductory tour of the repository via the [CodeTour extension](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -67,26 +67,3 @@ If you use [Visual Studio Code](https://code.visualstudio.com/) as your code edi
 ## Troubleshooting
 
 Please refer to our [Troubleshooting documentation](https://github.com/a11yproject/a11yproject.com/blob/main/TROUBLESHOOTING.md) for help with issues running the site.
-
-
-[numeronyms]: https://a11yproject.com/posts/a11y-and-other-numeronyms/
-[coc]: https://a11yproject.com/code-of-conduct/
-[contributing-guidelines]: https://a11yproject.com/contributing-guidelines/
-[content-style-guide]: https://a11yproject.com/content-style-guide/
-[11ty]: https://www.11ty.io/
-[markdown]: https://daringfireball.net/projects/markdown/syntax
-[sass]: https://sass-lang.com/
-[nunjucks]: https://mozilla.github.io/nunjucks/
-[json]: https://www.json.org/
-[terminal]: https://commandlinepoweruser.com/
-[hyper]: https://hyper.is/
-[git]: https://git-scm.com/
-[github]: https://github.com/
-[github-app]: https://desktop.github.com
-[node]: https://nodejs.org/en/
-[nvm]: https://github.com/creationix/nvm
-[root]: https://en.m.wikipedia.org/wiki/Root_directory
-[localhost]: http://localhost:3000
-[browsersync]: https://www.browsersync.io/
-[vscode]: https://code.visualstudio.com/
-[codetour]: https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour


### PR DESCRIPTION
Closes #980 

Hey there, just following up on #980 where the links in the `README.md` are all relative & therefore lead to 404 pages on github.com. So the goal of this PR is to make sure those links are valid.

It's possible I'm missing some context here, but I went ahead and updated the link paths in this PR and then removed the list of link references at the bottom of the file.

Please let me know if you disagree & I'm happy to restore / make changes.

Thank you! 💖