### PR TITLE
Fix for posts page author links

### DIFF
--- a/src/_includes/post.njk
+++ b/src/_includes/post.njk
@@ -3,7 +3,7 @@
 		<a class="c-card__title" href="{{ post.url | url }}">{{ post.data.title | safe }}</a>
 	</h3>
 	<p class="c-card__meta">
-		Published on <time datetime="{{ post.date | htmlDateString }}">{{ post.date | dateReadable }}</time>{% if post.data.author%} by <a class="c-card__author" href="{{ '/authors/#{{ post.data.author | slugify }}' | url}}">{{ post.data.author }}</a>{% endif %}
+		Published on <time datetime="{{ post.date | htmlDateString }}">{{ post.date | dateReadable }}</time>{% if post.data.author%} by <a class="c-card__author" href="{{ '/authors/#' + post.data.author | slugify | url}}">{{ post.data.author }}</a>{% endif %}
 	</p>
 	<p class="c-card__description">
 		{{ post.data.description | safe }}


### PR DESCRIPTION
Fix syntax error in nunjucks template.
Closes a11yproject/a11yproject.com#961

Signed-off-by: Ben Court <git@bencourt.co.uk>