### PR TITLE
Fix #987: Update id for Media section heading on Resources page

### DIFF
--- a/src/resources.njk
+++ b/src/resources.njk
@@ -21,7 +21,7 @@ templateClass: template-resources
 	{% endfor %}
 
 
-	<h2 id="animation" class="c-heading-large">
+	<h2 id="media" class="c-heading-large">
 		Media
 	</h2>
 


### PR DESCRIPTION
Fixes #987 

This PR updates the "Media" heading id on the Resources page.

This fixes an issue where two headings on the page have the same id ("animation") and also fixes the TOC link for the "Animation" section.