### PR TITLE
Fix #975 : Reworks avatar sizes and spacing across breakpoints

### DIFF
--- a/src/css/components/_c-person.scss
+++ b/src/css/components/_c-person.scss
@@ -4,8 +4,9 @@ $_person-distance: (
 );
 
 $_person-photo: (
-	small: 8rem,
-	medium: 10rem,
+	tiny: 4rem,
+	small: 6rem,
+	medium: 8rem,
 	large: 12rem
 );
 
@@ -18,36 +19,43 @@ $_person-photo: (
 	}
 }
 
+@mixin photo($size: tiny) {
+	height: map-get($_person-photo, $size);
+	width: map-get($_person-photo, $size);
+}
+
 
 // Photos use background images since we can't control the dimensions of
 // submitted avatars. This centers whatever is added, which hopefully creates a
 // good cropping effect.
 .c-person__photo {
+	@include photo(tiny);
+
 	background-position: center;
 	background-size: contain;
-	border-radius: map-get($_person-photo, small) * 2;
+	border-radius: 100%;
 	cursor: pointer;
 	display: inline-block;
-	height: map-get($_person-photo, small);
-	margin-top: -3.5rem;
+	margin-top: -2.75rem;
 	position: absolute;
-		right: 0.25rem;
-	width: map-get($_person-photo, small);
+		right: calc(50% - #{map-get($_person-photo, tiny)/2});
 
 	// Breakpoints
 	@include mappy-bp(wrist-large) {
-		right: 6vw;
+		@include photo(small);
+		right: 2rem;
 	}
 
 	@include mappy-bp(palm-small) {
-		right: 10vw;
+		@include photo(medium);
+		margin-top: -3.5rem;
+		right: 3rem;
 	}
 
 	@include mappy-bp(palm-medium) {
-		height: map-get($_person-photo, small);
+		@include photo(medium);
 		left: 1rem;
 		margin-top: -2rem;
-		width: map-get($_person-photo, small);
 	}
 
 	@include mappy-bp(palm-large) {
@@ -55,16 +63,16 @@ $_person-photo: (
 	}
 
 	@include mappy-bp(lap-small) {
+		@include photo(medium);
 		left: initial;
 		margin-left: 1rem;
 		right: initial;
 	}
 
 	@include mappy-bp(lap-medium) {
-		height: map-get($_person-photo, large);
+		@include photo(large);
 		margin-top: -3rem;
 		margin-left: -1rem;
-		width: map-get($_person-photo, large);
 	}
 
 	// User Queries
@@ -80,9 +88,9 @@ $_person-photo: (
 
 .c-person__info {
 	border: $border-thinnest solid $color-black;
-	margin-top: 5rem;
+	margin-top: 4rem;
 	min-height: 10rem;
-	padding: 1.5rem 4rem 1.5rem 1.5rem;
+	padding: 1.5rem;
 	max-width: $global-type-measure;
 	transition: $animation-duration-shorter $animation-easing-character background-color;
 
@@ -92,6 +100,10 @@ $_person-photo: (
 	}
 
 	// Breakpoints
+	@include mappy-bp(palm-small) {
+		margin-top: 5rem;
+	}
+
 	@include mappy-bp(palm-medium) {
 		margin-left: 5rem;
 		padding-left: 3rem;

--- a/src/css/components/_c-person.scss
+++ b/src/css/components/_c-person.scss
@@ -10,6 +10,10 @@ $_person-photo: (
 	large: 12rem
 );
 
+@mixin _person-photo-size($size: tiny) {
+	height: map-get($_person-photo, $size);
+	width: map-get($_person-photo, $size);
+}
 
 .c-person {
 	margin-top: 2rem;
@@ -19,17 +23,11 @@ $_person-photo: (
 	}
 }
 
-@mixin photo($size: tiny) {
-	height: map-get($_person-photo, $size);
-	width: map-get($_person-photo, $size);
-}
-
-
 // Photos use background images since we can't control the dimensions of
 // submitted avatars. This centers whatever is added, which hopefully creates a
 // good cropping effect.
 .c-person__photo {
-	@include photo(tiny);
+	@include _person-photo-size(tiny);
 
 	background-position: center;
 	background-size: contain;
@@ -42,18 +40,21 @@ $_person-photo: (
 
 	// Breakpoints
 	@include mappy-bp(wrist-large) {
-		@include photo(small);
+		@include _person-photo-size(small);
+
 		right: 2rem;
 	}
 
 	@include mappy-bp(palm-small) {
-		@include photo(medium);
+		@include _person-photo-size(medium);
+
 		margin-top: -3.5rem;
 		right: 3rem;
 	}
 
 	@include mappy-bp(palm-medium) {
-		@include photo(medium);
+		@include _person-photo-size(medium);
+
 		left: 1rem;
 		margin-top: -2rem;
 	}
@@ -63,14 +64,16 @@ $_person-photo: (
 	}
 
 	@include mappy-bp(lap-small) {
-		@include photo(medium);
+		@include _person-photo-size(medium);
+
 		left: initial;
 		margin-left: 1rem;
 		right: initial;
 	}
 
 	@include mappy-bp(lap-medium) {
-		@include photo(large);
+		@include _person-photo-size(large);
+
 		margin-top: -3rem;
 		margin-left: -1rem;
 	}


### PR DESCRIPTION
This is a fix for Issue #975 

**This PR:**

- Adds a height/width Sass mixin for different photo sizes to pare down on code
- Adds a `tiny` image size and adjusts the other values as some weren't being used
- Adjusts the spacing and orientation of the avatar images per breakpoint

**Tasks from the issue:**

- [x] Add a tiny photo size to the $_person-photo Sass map.
- [x] Tweak the incorporating breakpoint declarations to incorporate it.
- [x] Verify using a smartphone.


**Screenshots of the element at different breakpoints:**

![Screenshot_12](https://user-images.githubusercontent.com/2972688/87885615-e3cbe500-c9dc-11ea-97a2-613b4ccc2f0d.png)
![Screenshot_16](https://user-images.githubusercontent.com/2972688/87885616-e4647b80-c9dc-11ea-998a-8775fdef1722.png)
![Screenshot_15](https://user-images.githubusercontent.com/2972688/87885617-e4647b80-c9dc-11ea-9c85-d32d2088fdb0.png)
![Screenshot_14](https://user-images.githubusercontent.com/2972688/87885618-e4647b80-c9dc-11ea-8a22-2d525cc28676.png)
![Screenshot_13](https://user-images.githubusercontent.com/2972688/87885619-e4fd1200-c9dc-11ea-831f-d005bdfe7252.png)
