### PR TITLE
Remove Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "the-a11y-project",
 	"description": "A community-driven effort to make digital accessibility easier.",
 	"homepage": "https://a11yproject.com/",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"license": "Apache-2.0",
 	"author": "Dave Rupert <hello@a11yproject.com> (https://daverupert.com/)",
 	"contributors": [

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -1,7 +1,6 @@
 <!DOCTYPE html class="no-js">
 <html lang="en" itemscope itemtype="http://schema.org/Webpage">
 	<head>
-		{% include "meta/analytics.njk" %}
 		<meta charset="utf-8">
 		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/_includes/meta/analytics.njk
+++ b/src/_includes/meta/analytics.njk
@@ -1,7 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-2419836-9"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-2419836-9');
-</script>

--- a/src/privacy-and-security.njk
+++ b/src/privacy-and-security.njk
@@ -26,12 +26,9 @@ templateClass: template-generic
 		Privacy
 	</h2>
 	<p>
-		We use <a href="https://analytics.google.com/">Google Analytics</a> to collect basic information, including data on pages visited, amount of time spent, generalized geographic information, and incoming and outgoing sites. This information is used to help make improvements to the website's content and design.
+		We use <a href="https://www.netlify.com/products/analytics/">Netlify Analytics</a> to collect basic information, including data on pages visited, amount of time spent, generalized geographic information, and incoming and outgoing sites. This information is used to help make improvements to the website's content and design.
 	</p>
-	<p>
-		We are currently in the process of <a href="https://github.com/a11yproject/a11yproject.com/issues/737">moving off of Google Analytics</a>. If you wish to opt out of data collection, you can do so with <a href="https://tools.google.com/dlpage/gaoptout">the Google Analytics Opt-out Browser Add-on</a>.
-	<p>
-		This website uses <a href="https://en.wikipedia.org/wiki/HTTPS">the HTTPS protocol</a> to help ensure the secure communication of data from this website to your browser. It also serves static, pre-compiled content. Access to Google Analytics information is restricted to site administrators.
+		This website uses <a href="https://en.wikipedia.org/wiki/HTTPS">the HTTPS protocol</a> to help ensure the secure communication of data from this website to your browser. It also serves static, pre-compiled content. Access to Netlify Analytics information is restricted to site administrators.
 	</p>
 	<p>
 		To review the history of our privacy policy, you can check the <a href="https://github.com/a11yproject/a11yproject.com/blob/main/src/privacy-and-security.njk">edits made to this page on GitHub</a>. If you have questions about our privacy policies, please reach out to <a data-mailto href="mailto:hello@a11yproject.com?subject=Privacy%20policy">hello@a11yproject.com</a>.


### PR DESCRIPTION
This PR removes Google Analytics from the site. We now use Netlify Analytics. See https://github.com/a11yproject/a11yproject.com/issues/737.