### PR TITLE
Fix #966: Adjust styles of hero and header components for short viewports

### DIFF
--- a/src/css/components/_c-a11y-summary.scss
+++ b/src/css/components/_c-a11y-summary.scss
@@ -9,6 +9,7 @@
 	background-color: $color-white;
 	border-top: $border-thicker solid $color-pink-tint;
 	padding: 1.5rem;
+	margin: 2rem 0;
 
 	@include mappy-bp(palm-large) {
 		padding: 2rem 7rem 2.75rem 7rem;

--- a/src/css/components/_c-cta-get-started.scss
+++ b/src/css/components/_c-cta-get-started.scss
@@ -15,6 +15,10 @@
 		bottom: 2rem;
 	text-align: center;
 
+	@include mappy-bp(lap-large) {
+		bottom: 2.25rem;
+	}
+
 	// Supports
 	@supports #{$supports-grid} {
 		display: grid;

--- a/src/css/layout/_l-header.scss
+++ b/src/css/layout/_l-header.scss
@@ -3,4 +3,9 @@
 	@supports #{$supports-grid} {
 		grid-area: header;
 	}
+
+	@supports #{$supports-flex} {
+		display: flex;
+		flex-direction: column;
+	}
 }

--- a/src/css/layout/_l-header.scss
+++ b/src/css/layout/_l-header.scss
@@ -3,9 +3,4 @@
 	@supports #{$supports-grid} {
 		grid-area: header;
 	}
-
-	@supports #{$supports-flex} {
-		display: flex;
-		flex-direction: column;
-	}
 }

--- a/src/css/layout/_l-hero.scss
+++ b/src/css/layout/_l-hero.scss
@@ -1,5 +1,12 @@
 .l-hero {
-	height: 75vh;
+	position: relative;
+	height: auto;
+	padding: map-get($global-bleed, small) 0;
+
+	@include mappy-bp(lap-large) {
+		height: 75vh;
+		min-height: rem(425);
+	}
 
 	// Contexts
 	.template-posts &,
@@ -29,18 +36,6 @@
 			justify-content: center;
 		}
 	}
-
-	@supports #{$supports-grid} {
-		// Breakpoints
-		@include mappy-bp(lap-small) {
-			display: grid;
-			grid-template-rows: 1fr 1fr 1fr 3rem;
-			grid-template-areas:
-				". .    ."
-				". hero ."
-				". .    .";
-		}
-	}
 }
 
 
@@ -48,8 +43,8 @@
 	margin-left: map-get($global-bleed, small);
 	margin-right: map-get($global-bleed, small);
 	position: relative;
-		top: 50%;
-	transform: perspective(1px) translateY(-60%); // HACK: Keeps content from rendering blurry
+	top: unset;
+	transform: perspective(1px) translateY(0); // HACK: Keeps content from rendering blurry
 
 	// Supports
 	@supports #{$supports-flex} {
@@ -85,6 +80,10 @@
 
 		@include mappy-bp(lap-small) {
 			margin: 0;
+		}
+
+		@include mappy-bp(lap-large) {
+			margin-bottom: rem(50);
 		}
 	}
 }


### PR DESCRIPTION
Resolves #966 

As @aardrian pointed out in #966, the `height: 75vh` rule on the header is causing header content to cover the page navigation when the viewport height is shortened. As the viewport height is reduced, there is less space for the header's content.

I believe there are also a couple other styles contributing to this effect, and I've tried to edit only what's required to prevent the navigation from being covered up & also mimic the the layout of the current deployment. In addition, there a secondary side-effect where the CTA was covering up the numeronym definition, which meant making a couple grid edits.

Please take a look and let me know what you think! **I had some issues with cached styles while looking into this, so please run these updates locally & let me know if there is something amiss.**