### PR TITLE
Fix #950: Safari focus outline bug

### DIFF
--- a/src/css/base/_links.scss
+++ b/src/css/base/_links.scss
@@ -6,15 +6,14 @@
 //
 // Styleguide Base.link
 a {
-	// States
-	&:hover,
-	&:focus {
-		text-decoration: none;
+	// Style links that don't have a class declared on them
+	&[href]:not([class]) {
+		// States
+		&:hover,
+		&:focus {
+			text-decoration: none;
+		}
 	}
-
-	// Styles links that don't have a class declared on them
-	// &[href]:not([class]) {
-	// }
 
 	// Display links when the `<a>` element has no text value but the href
 	// attribute has a link


### PR DESCRIPTION
Resolves the last remaining issue in #950, i.e. `Focus state on sponsors`. 

***

In Safari, the custom focus outline on sponsor images doesn't appear on focus. This PR resolves that issue. Tested in the latest versions of Safari, Firefox, and Chrome on Mac OS X 10.14.6. [More details in the commit](https://github.com/a11yproject/a11yproject.com/commit/8681d13c12a745eb078714003af078a895b68298). 

I still don't know the exact source of the issue, and couldn't easily reproduce it using a reduced test case codepen. I think it may be related to a combination of several styles, including `text-decoration` and possibly `display` or flex/grid layout. I may spend a little more time investigating and will update this PR if I learn more. 

### Before

#### Safari

<img width="1090" alt="Sponsors section of a11yproject.com showing no focus outline" src="https://user-images.githubusercontent.com/7654254/88800947-ebc31c00-d176-11ea-81a7-5e82aad555cb.png">

### After

#### Safari

<img width="1087" alt="Sponsors section of a11yproject.com showing correct focus outline" src="https://user-images.githubusercontent.com/7654254/88800943-ea91ef00-d176-11ea-9515-11efbf4b46a1.png">

#### Firefox

<img width="1090" alt="Screen Shot 2020-07-29 at 8 35 50 AM" src="https://user-images.githubusercontent.com/7654254/88801602-ec0fe700-d177-11ea-923f-387047a18f16.png">

#### Chrome

<img width="1086" alt="Screen Shot 2020-07-29 at 8 36 13 AM" src="https://user-images.githubusercontent.com/7654254/88801607-eca87d80-d177-11ea-8e22-1e8335d19f71.png">

