### PR TITLE
Remove markdownItAnchor

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -81,21 +81,13 @@ module.exports = function (eleventyConfig) {
 
   /* Markdown Plugins */
   let markdownIt = require("markdown-it");
-  let markdownItAnchor = require("markdown-it-anchor");
   let options = {
     html: true,
     breaks: true,
     linkify: true
   };
-  let opts = {
-    permalink: true,
-    permalinkClass: "direct-link",
-    permalinkSymbol: "#"
-  };
 
-  eleventyConfig.setLibrary("md", markdownIt(options)
-    .use(markdownItAnchor, opts)
-	);
+  eleventyConfig.setLibrary("md", markdownIt(options));
 
 	eleventyConfig.addTransform("htmlmin", function (content, outputPath) {
     if (


### PR DESCRIPTION
Rationale: markdownItAnchor adds links with the hash symbol (#) to the headings of any page but those links are marked `aria-hidden="true"` which produces empty links that can be reached by keyboard. It is confusing for users of assistive technology. 

In an attempt to fix it one could add `tabindex="-1"` to those links, making them unavailable for keyboard users. But that would also be an issue.

I think the optimal solution is having a switch to turn those links on and adding an `aria-label` that says “Direct link to [this section] of the page”, with [this section] replaced by the name of the section.

Until a better solution exists I would remove the functionality as a whole.