### PR TITLE
Fix copy error within the animation checklist item

### DIFF
--- a/src/_data/checklists.json
+++ b/src/_data/checklists.json
@@ -353,7 +353,7 @@
 	],
 	"animation": [
 		{
-			"title": "Ensure animations are subtle and not do not flash too much.",
+			"title": "Ensure animations are subtle and do not flash too much.",
 			"wcag": "2.3.1 Three Flashes or Below Threshold",
 			"url": "https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html",
 			"description": "Certain kinds of strobing or flashing animations will trigger seizures. Others may be distracting and disruptive, especially for certain kinds of cognitive disability such as ADHD."


### PR DESCRIPTION
This commit removes a duplicate "not" within the animation title string.