### PR TITLE
Add verb to touch target guidance

### DIFF
--- a/src/_data/checklists.json
+++ b/src/_data/checklists.json
@@ -488,7 +488,7 @@
 			"description": "Requiring someone to scroll horizontally can be difficult for some, irritating for all."
 		},
 		{
-			"title": "Button and link icons can be activated with ease.",
+			"title": "Ensure that button and link icons can be activated with ease.",
 			"checkboxId": "easy-activation",
 			"wcag": "2.5.5 Target Size",
 			"url": "https://www.w3.org/WAI/WCAG21/Understanding/target-size.html",


### PR DESCRIPTION
Most (all) of the other criteria in the checklist begin with verb phrases; this copyedit brings the touch target guidance in line with that trend.