### PR TITLE
Update 404’s templateClass

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -6,7 +6,7 @@ eleventyNavigation:
   key: Page not found
 tags:
   - 404
-templateClass: template-404
+templateClass: template-simple
 permalink: 404.html
 eleventyExcludeFromCollections: true
 ---


### PR DESCRIPTION
This PR updates our 404 page to use the same `templateClass` that the rest of our pages using the same layout do.