### PR TITLE
Added persistence for the Table of Contents component.

### DIFF
--- a/src/js/table-of-contents/table-of-contents.js
+++ b/src/js/table-of-contents/table-of-contents.js
@@ -1,5 +1,6 @@
 /* jshint esversion: 5 */
 /*! tableOfContents.js v1.0.0 | (c) 2020 Chris Ferdinandi | MIT License | http://github.com/cferdinandi/table-of-contents */
+/* Modified by Jeremy L. Wagner to add persistence via localStorage
 /*
  * Automatically generate a table of contents from the headings on the page
  * @param  {String} content A selector for the element that the content is in
@@ -13,6 +14,11 @@ var tableOfContents = function (content, target, options) {
   // Get content
   var contentWrap = document.querySelector(content);
   var toc = document.querySelector(target);
+  var enableTOCPersistence = 'localStorage' in window && toc !== null && toc.parentNode.nodeName === 'DETAILS';
+  var idleCallbackAvailable = 'requestIdleCallback' in window;
+  var tocKey = location.pathname;
+  var tocState = [];
+  var localStorageKey = 'TOCState';
   if (!contentWrap || !toc) return;
   // Settings & Defaults
   var defaults = {
@@ -27,10 +33,10 @@ var tableOfContents = function (content, target, options) {
   //
   // Methods
   //
-	/**
-	 * Merge user options into defaults
-	 * @param  {Object} obj The user options
-	 */
+  /**
+   * Merge user options into defaults
+   * @param  {Object} obj The user options
+   */
   var merge = function (obj) {
     for (var key in defaults) {
       if (Object.prototype.hasOwnProperty.call(defaults, key)) {
@@ -38,19 +44,19 @@ var tableOfContents = function (content, target, options) {
       }
     }
   };
-	/**
-	 * Create an ID for a heading if one does not exist
-	 * @param  {Node} heading The heading element
-	 */
+  /**
+   * Create an ID for a heading if one does not exist
+   * @param  {Node} heading The heading element
+   */
   var createID = function (heading) {
     if (heading.id.length) return;
     heading.id = 'toc_' + heading.textContent.replace(/[^A-Za-z0-9]/g, '-');
   };
-	/**
-	 * Get the HTML to indent a list a specific number of levels
-	 * @param  {Integer} count The number of times to indent the list
-	 * @return {String}        The HTML
-	 */
+  /**
+   * Get the HTML to indent a list a specific number of levels
+   * @param  {Integer} count The number of times to indent the list
+   * @return {String}        The HTML
+   */
   var getIndent = function (count) {
     var html = '';
     for (var i = 0; i < count; i++) {
@@ -58,11 +64,11 @@ var tableOfContents = function (content, target, options) {
     }
     return html;
   };
-	/**
-	 * Get the HTML to close an indented list a specific number of levels
-	 * @param  {Integer} count The number of times to "outdent" the list
-	 * @return {String}        The HTML
-	 */
+  /**
+   * Get the HTML to close an indented list a specific number of levels
+   * @param  {Integer} count The number of times to "outdent" the list
+   * @return {String}        The HTML
+   */
   var getOutdent = function (count) {
     var html = '';
     for (var i = 0; i < count; i++) {
@@ -70,12 +76,12 @@ var tableOfContents = function (content, target, options) {
     }
     return html;
   };
-	/**
-	 * Get the HTML string to start a new list of headings
-	 * @param  {Integer} diff  The number of levels in or out from the current level the list is
-	 * @param  {Integer} index The index of the heading in the "headings" NodeList
-	 * @return {String}        The HTML
-	 */
+  /**
+   * Get the HTML string to start a new list of headings
+   * @param  {Integer} diff  The number of levels in or out from the current level the list is
+   * @param  {Integer} index The index of the heading in the "headings" NodeList
+   * @return {String}        The HTML
+   */
   var getStartingHTML = function (diff, index) {
     // If indenting
     if (diff > 0) {
@@ -91,15 +97,84 @@ var tableOfContents = function (content, target, options) {
     }
     return '';
   };
-	/**
-	 * Inject the table of contents into the DOM
-	 */
+  /**
+   * Adds an event listener to the TOC if localStorage is available
+   */
+  var bindTOCToggle = function () {
+    toc.parentNode.addEventListener('toggle', function (event) {
+      openState = event.target.getAttribute('open') === '';
+
+      // We only check for the presence of the current page (tocKey) in the
+      // tocState array to determine if the ToC needs to be closed, because the
+      // default state for a ToC is to be open. The presence of the tocKey in
+      // the array means the ToC has been shut.
+      if (!openState) {
+        if (tocState.indexOf(tocKey) === -1) {
+          tocState.push(tocKey);
+        }
+      } else {
+        var index = tocState.indexOf(tocKey);
+
+        if (index > -1) {
+          tocState.splice(index, 1);
+        }
+      }
+
+      writeTOCState(tocState);
+    });
+  };
+  /**
+   * Writes the TOC state to localStorage
+   */
+  var writeTOCState = function () {
+    var writeToStorage = function () {
+      localStorage.setItem(localStorageKey, JSON.stringify(tocState));
+    };
+
+    // localStorage is a synchronous API that can block the main thread. If
+    // requestIdleCallback is available, use that to defer writes to a period of
+    // time in which the main thread is idle.
+    if (idleCallbackAvailable) {
+      requestIdleCallback(writeToStorage);
+
+      return;
+    }
+
+    writeToStorage();
+  };
+  /**
+   * Gets the initial state of the TOC
+   */
+  var initTOCPersistence = function () {
+    // Get the TOC state from local storage
+    initialTOCState = localStorage.getItem(localStorageKey);
+
+    // Bind the toggle event on the TOC <details> element
+    bindTOCToggle();
+
+    // Check if there was a previous entry
+    if (initialTOCState !== null) {
+      tocState = JSON.parse(initialTOCState);
+    }
+
+    if (tocState.indexOf(tocKey) !== -1) {
+      toc.parentNode.removeAttribute('open');
+    }
+  };
+  /**
+   * Inject the table of contents into the DOM
+   */
   var injectTOC = function () {
     // Track the current heading level
     var level = headings[0].tagName.slice(1);
     var startingLevel = level;
     // Cache the number of headings
     var len = headings.length - 1;
+    // Check if localStorage is available and if ToC persistence is needed.
+    if (enableTOCPersistence) {
+      // Intialize ToC persistence
+      initTOCPersistence();
+    }
     // Inject the HTML into the DOM
     toc.innerHTML =
       '<' + settings.headingLevel + '>' + settings.heading + '</' + settings.headingLevel + '>' +
@@ -126,9 +201,9 @@ var tableOfContents = function (content, target, options) {
       }).join('') +
       '</' + settings.listType + '>';
   };
-	/**
-	 * Initialize the script
-	 */
+  /**
+   * Initialize the script
+   */
   var init = function () {
     // Merge any user settings into the defaults
     merge(options || {});


### PR DESCRIPTION
Persists Table of Contents open/closed state across navigations using `localStorage`. Tested on:

- Firefox Nightly on macOS 10.15.6
- Chrome Canary on macOS 10.15.6
- Safari Technical Preview on macOS 10.15.6
- Chrome on Android 7.1.1
- Safari on iOS 14.0.1

Modifications are made to Chris Ferdinandi's tableOfContents.js. The persistence is only enabled on pages where a `toc` element is available, its `parentNode` is a `<details>` element, and `localStorage` is available.