### PR TITLE
Link to stable version of WAI tutorial

### DIFF
--- a/src/posts/2020-09-19-how-to-write-accessible-forms.md
+++ b/src/posts/2020-09-19-how-to-write-accessible-forms.md
@@ -6,9 +6,9 @@ category: How-to
 author: Hamsa Harcourt
 date: 2020-09-16
 further_reading:
-  - title: Error Messages
-    url: https://www.w3.org/WAI/EO/Drafts/tutorials/forms/error-messages/
-    source:  Web accessibility tutorials
+  - title: User Notifications
+    url: https://www.w3.org/WAI/tutorials/forms/notifications/
+    source:  WAI Web Accessibility Tutorials
     year: 2014
   - title: Provide helpful error messages
     url: https://accessibility.huit.harvard.edu/provide-helpful-error-messages


### PR DESCRIPTION
The link was to a rough draft of the WAI Tutorials. This updates it to be to the stable version of this page and tweaks link text.