### PR TITLE
Fix colour contrast in focused state (fixes #1127)

### DIFF
--- a/src/css/components/_c-card.scss
+++ b/src/css/components/_c-card.scss
@@ -81,6 +81,17 @@ $_card-outline: $border-thinner solid;
 			background-color: $color-green-tint;
 			border: none;
 		}
+
+		.template-resources &:focus-within {
+
+			.c-card__title,
+			.c-card__meta,
+			.c-card__author,
+			.c-card__description, {
+				color: $color-black;
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
The white text colour has insufficient contrast with the green tint used for the highlighted card in template resources. This PR fixes that.

Focus card state, before: 

<img width="794" alt="card with light green background and white text" src="https://user-images.githubusercontent.com/178782/95960564-2c404680-0e04-11eb-8db9-ee3a853e5ce2.png">

Focus card state, after:

<img width="797" alt="card with black text on light green background" src="https://user-images.githubusercontent.com/178782/95960664-4d089c00-0e04-11eb-907d-f21d88b7ff95.png">
