### PR TITLE
Add a11y-contrast tool

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -385,6 +385,12 @@
 	],
 	"colors": [
 		{
+			"title": "a11y-contrast",
+			"description": "A CLI utility to calculate/verify accessible magic numbers for a color palette.",
+			"additional": "Darek Kay",
+			"url": "https://github.com/darekkay/a11y-contrast"
+		},
+		{
 			"title": "Accessibility Tester",
 			"description": "Pick any color to generate an accessible palette.",
 			"additional": "Confrere",


### PR DESCRIPTION
I have written [a11y-contrast](https://github.com/darekkay/a11y-contrast), a small CLI utility for creating accessible color palettes. It's based on the approach that USWDS [uses](https://designsystem.digital.gov/design-tokens/color/overview/) to ensure accessible color contrast ratios on their websites. I have [written](https://darekkay.com/blog/accessible-color-palette/) about this "magic number" approach on my blog before.