### PR TITLE
Link the follow page to a more recent resource

### DIFF
--- a/src/follow.njk
+++ b/src/follow.njk
@@ -25,7 +25,7 @@ templateClass: template-generic
 		Who to follow
 	</h2>
 	<p>
-		<a href="https://joe-watkins.io/">Joe Watkins</a> maintains a list of notable <a href="https://github.com/joe-watkins/top-people-to-follow-in-web-accessibility#people">people</a>, <a href="https://github.com/joe-watkins/top-people-to-follow-in-web-accessibility#companies--organizations">companies and organizations</a>, and <a href="https://github.com/joe-watkins/top-people-to-follow-in-web-accessibility#meetups">meetups</a> that contribute to digital accessibility and open standards.
+		<a href="https://brunopulis.com/">Bruno Pulis</a> maintains a list of notable <a href="https://github.com/brunopulis/awesome-a11y/blob/master/topics/people.md">people</a>, <a href="https://github.com/brunopulis/awesome-a11y/blob/master/topics/companies-and-organizations.md">companies and organizations</a>, and <a href="https://github.com/brunopulis/awesome-a11y/blob/master/topics/meetups.md">meetups</a> that contribute to digital accessibility and open standards.
 	</p>
 	<h2 id="follow-the-a11y-project" class="c-heading-large">
 		Follow The A11Y Project


### PR DESCRIPTION
As discussed in #707, [Joe's list](https://github.com/joe-watkins/top-people-to-follow-in-web-accessibility) is a great, but unfortunately outdated resource.

This PR changes the "Who to follow" link to [awesome-a11y](https://github.com/brunopulis/awesome-a11y), which is actively maintained.