### PR TITLE
Adds flex wrap on v-toc_nav a for proper wrapping

### DIFF
--- a/src/css/vendor/_v-toc.scss
+++ b/src/css/vendor/_v-toc.scss
@@ -167,7 +167,11 @@
 
 		code {
 			text-transform: none;
-			margin: 0 0.5rem;
+			line-height: 1.1;
+
+			@supports not (gap: 0.5rem) {
+				margin: 0 0.5rem;
+			}
 		}
 
 		li {
@@ -207,6 +211,7 @@
 			border-bottom: none;
 			display: flex;
 			flex-wrap: wrap;
+			gap: 0.5rem;
 
 			&::after {
 				content: "";

--- a/src/css/vendor/_v-toc.scss
+++ b/src/css/vendor/_v-toc.scss
@@ -167,6 +167,7 @@
 
 		code {
 			text-transform: none;
+			margin: 0 0.5rem;
 		}
 
 		li {
@@ -205,6 +206,7 @@
 		@supports #{$supports-flex} {
 			border-bottom: none;
 			display: flex;
+			flex-wrap: wrap;
 
 			&::after {
 				content: "";


### PR DESCRIPTION
Fixes #1150 

Also added a bit of margin on both sides of `<code>` in v-toc_nav