### PR TITLE
Puts toc text inside <span> tag

### DIFF
--- a/src/css/vendor/_v-toc.scss
+++ b/src/css/vendor/_v-toc.scss
@@ -167,10 +167,7 @@
 		code {
 			text-transform: none;
 			line-height: 1.1;
-
-			@supports not (gap: 0.5rem) {
-				margin: 0 0.5rem;
-			}
+			overflow-y: hidden;
 		}
 
 		li {
@@ -210,8 +207,6 @@
 		@supports #{$supports-flex} {
 			border-bottom: none;
 			display: flex;
-			flex-wrap: wrap;
-			gap: 0.5rem;
 
 			&::after {
 				content: "";

--- a/src/js/table-of-contents/table-of-contents.js
+++ b/src/js/table-of-contents/table-of-contents.js
@@ -191,7 +191,7 @@ var tableOfContents = function (content, target, options) {
         html +=
           '<li>' +
           '<a href="#' + heading.id + '">' +
-          heading.innerHTML.trim() +
+          '<span>' + heading.innerHTML.trim() + '</span>' +
           '</a>';
         // If the last item, close it all out
         if (index === len) {


### PR DESCRIPTION
Fixes #1150

I have put all the innerHTML content inside a `<span>` tag so that the flex can only be between the text and `:after` focus line. Also added `overflow-y: hidden` for code inside toc. This should solve all the problems.

I was trying to avoid putting a `<span>` inside an `<a>` tag, but maybe it's not too horrible? And feel like fixes the design bugs.

@ericwbailey @aardrian what do you think?