### PR TITLE
Replace redundant “Ideal” in the Checklist

### DIFF
--- a/src/checklist.njk
+++ b/src/checklist.njk
@@ -51,7 +51,7 @@ templateClass: template-checklist
 				<img alt="" src="/img/checklist/wcag-level-aaa-small.svg" />
 			</picture>
 			<p class="c-wcag-explanation__description">
-				<strong class="u-font-size-body-medium c-wcag-explanation__conformance-level">AAA: Ideal Support</strong>
+				<strong class="u-font-size-body-medium c-wcag-explanation__conformance-level">AAA: Specialized Support</strong>
 				This is typically reserved for parts of websites and web apps that serve a specialized audience.
 			</p>
 		</div>


### PR DESCRIPTION
This PR replaces "ideal" in AAA support with "specialized." Issue reported via our contact form.