### PR TITLE
Restore Yakim van Zuijlen’s article on VoiceOver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "the-a11y-project",
-	"version": "1.4.1",
+	"version": "1.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1349,6 +1349,12 @@
 			"url": "https://developer.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/"
 		},
 		{
+			"title": "How to start testing screen reader support using VoiceOver",
+			"description": "This article explains why you should be testing your content with a screen reader. It also gives a visual guide on how to use VoiceOver on macOS",
+			"additional": "Yakim van Zuijlen",
+			"url": "https://yakim.nl/articles/voiceover-testing/"
+		},
+		{
 			"title": "The Importance Of Manual Accessibility Testing",
 			"description": "Automated accessibility tests are a great resource to have, but they can’t automatically make your site accessible. Use them as one step of a larger testing process.",
 			"additional": "Smashing Magazine",


### PR DESCRIPTION
This PR re-adds [Yakim van Zuijlen’s article](https://yakim.nl/articles/voiceover-testing/), accidentally removed in https://github.com/a11yproject/a11yproject.com/pull/1189, and noted by @yakimvanzuijlen [here](https://github.com/a11yproject/a11yproject.com/commit/60a8b60090d7ee3a3bf4d3cafa307c7681dd48db#commitcomment-46990386).