### PR TITLE
Update The Paciello Group’s name to TPGi

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -77,8 +77,8 @@
 			"url": "http://www.lowvisionary.com/"
 		},
 		{
-			"title": "The Paciello Group Blog",
-			"description": "A blog about accessibility written by the The Paciello Group's employees.",
+			"title": "TPGi Blog",
+			"description": "A blog about accessibility written by the TPGi's employees.",
 			"url": "https://developer.paciellogroup.com/blog/"
 		},
 		{
@@ -126,7 +126,7 @@
 		{
 			"title": "Nu Markup Validation Service Bookmarklets",
 			"description": "The W3C Nu Markup Validator checks the markup validity of Web documents, but instead uses the backend from the Validator.nu engine.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://developer.paciellogroup.com/blog/2012/06/nu-markup-validation-service-bookmarklets/"
 		},
 		{
@@ -282,7 +282,7 @@
 		{
 			"title": "ARC Toolkit",
 			"description": "ARC Toolkit is a professional-level accessibility testing tool that gives you the power to quickly and efficiently evaluate screens for accessibility and uncover issues related to the WCAG 2.1 Level A and AA guidelines.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://www.paciellogroup.com/toolkit/",
 			"browsers": [
 				"Chrome"
@@ -376,7 +376,7 @@
 		{
 			"title": "Web Accessibility Toolbar",
 			"description": "The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://developer.paciellogroup.com/resources/wat/",
 			"browsers": [
 				"Internet Explorer"
@@ -651,7 +651,7 @@
 		{
 			"title": "ARC",
 			"description": "Automated testing that looks for machine-detectable accessibility defects within digital content.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://www.paciellogroup.com/products/accessibility-resource-center-arc/"
 		},
 		{
@@ -1228,8 +1228,8 @@
 			"url": "https://knowbility.org/"
 		},
 		{
-			"title": "The Paciello Group",
-			"description": "The Paciello Group – Your Accessibility Partner (WCAG 2.0/508 audits, VPAT, usability and accessible user experience).",
+			"title": "TPGi",
+			"description": "TPGi – Your Accessibility Partner (WCAG 2.0/508 audits, VPAT, usability and accessible user experience).",
 			"url": "https://www.paciellogroup.com/"
 		},
 		{
@@ -1345,7 +1345,7 @@
 		{
 			"title": "Basic screen reader commands for accessibility testing",
 			"description": "When you test your website with a screen reader there are a few basic commands you should know.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://developer.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/"
 		},
 		{
@@ -1537,7 +1537,7 @@
 		{
 			"title": "Colour Contrast Analyser",
 			"description": "The Colour Contrast Analyser (CCA) helps you determine the legibility of text and the contrast of visual elements, such as graphical controls and visual indicators.",
-			"additional": "The Paciello Group",
+			"additional": "TPGi",
 			"url": "https://developer.paciellogroup.com/resources/contrastanalyser/",
 			"platforms": [
 				"macOS",

--- a/src/posts/2013-01-11-how-to-hide-content.md
+++ b/src/posts/2013-01-11-how-to-hide-content.md
@@ -16,6 +16,10 @@ further_reading:
     url: https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
     source: Scott O'Hara
     year: 2017/2019
+  - title: Hiding Content Responsibly
+    url: https://hugogiraudel.com/2021/02/17/hiding-content-responsibly/
+    source: Kitty Giraudel
+    year: 2021
 eleventyNavigation:
   key: {{ category }}
   title: {{ title }}

--- a/src/posts/2015-01-05-what-is-color-contrast.md
+++ b/src/posts/2015-01-05-what-is-color-contrast.md
@@ -48,7 +48,7 @@ This doesn't mean colors should only be limited to contrasting colors, but inste
 
 - [Tanaguru Contrast Finder](http://contrast-finder.tanaguru.com/)
 - [Contrast Ratio by Lea Verou](http://leaverou.github.io/contrast-ratio/)
-- [Colour Contrast Analyzer by Paciello Group](https://developer.paciellogroup.com/resources/contrastanalyser/)
+- [Colour Contrast Analyzer by TPGi](https://developer.paciellogroup.com/resources/contrastanalyser/)
 - [Color Contrast Checker by WebAIM](https://webaim.org/resources/contrastchecker/)
 
 These tools test your colors against a contrast ratio.

--- a/src/posts/2016-01-07-placeholder-input-elements.md
+++ b/src/posts/2016-01-07-placeholder-input-elements.md
@@ -14,7 +14,7 @@ further_reading:
     year: 2018
   - title: "HTML5 Accessibility Chops: the placeholder attribute"
     url: https://developer.paciellogroup.com/blog/2011/02/html5-accessibility-chops-the-placeholder-attribute/
-    source: The Paciello Group
+    source: TPGi
     year: 2011
   - title: Using @placeholder on Input
     url: https://www.w3.org/WAI/GL/wiki/Using_@placeholder_on_input

--- a/src/posts/2019-02-15-creating-valid-and-accessible-links.md
+++ b/src/posts/2019-02-15-creating-valid-and-accessible-links.md
@@ -64,7 +64,7 @@ The `title` attribute is not exposed by all browsers in an accessible way meanin
 <blockquote>
 	<p>If you want to hide content from mobile and tablet users as well as assistive tech users and keyboard only users, use the title attribute.</p>
 	<footer>
-		<cite><a href="https://developer.paciellogroup.com/blog/2010/11/using-the-html-title-attribute/">Using the HTML title attribute - The Paciello Group</a></cite>
+		<cite><a href="https://developer.paciellogroup.com/blog/2010/11/using-the-html-title-attribute/">Using the HTML title attribute - TTPGi</a></cite>
 	</footer>
 </blockquote>
 

--- a/src/posts/2020-05-13-aria-has-perfect-support.md
+++ b/src/posts/2020-05-13-aria-has-perfect-support.md
@@ -14,7 +14,7 @@ further_reading:
     source: PowerMapper Software
   - url: https://developer.paciellogroup.com/blog/2018/07/short-note-on-aria-support/
     title: Short note on ARIA support
-    source: The Paciello Group
+    source: TPGi
   - url: https://css-tricks.com/aria-spackle-not-rebar/
     title: ARIA is Spackle, Not Rebar
     source: CSS-Tricks

--- a/src/posts/2020-09-19-how-to-write-accessible-forms.md
+++ b/src/posts/2020-09-19-how-to-write-accessible-forms.md
@@ -24,7 +24,7 @@ further_reading:
     year: 2018
   - title: "HTML5 Accessibility Chops: the placeholder attribute"
     url: https://developer.paciellogroup.com/blog/2011/02/html5-accessibility-chops-the-placeholder-attribute/
-    source: The Paciello Group
+    source: TPGi
     year: 2011
   - title: Using @placeholder on Input
     url: https://www.w3.org/WAI/GL/wiki/Using_@placeholder_on_input

--- a/src/posts/2021-01-28-how-to-use-the-tabindex-attribute.md
+++ b/src/posts/2021-01-28-how-to-use-the-tabindex-attribute.md
@@ -14,7 +14,7 @@ further_reading:
     source: Google Developers
   - title: Using the tabindex attribute
     url: https://developer.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/
-    source: The Paciello Group
+    source: The TPGi
   - title: Don’t Use Tabindex Greater than 0
     url: https://adrianroselli.com/2014/11/dont-use-tabindex-greater-than-0.html
     source: Adrian Roselli
@@ -23,7 +23,7 @@ further_reading:
     source: Scott O'Hara
   - title: Short note on improving usability of scrollable regions
     url: https://developer.paciellogroup.com/blog/2016/02/short-note-on-improving-usability-of-scrollable-regions/
-    source: The Paciello Group
+    source: The TPGi
   - title: The difference between keyboard and screen reader navigation
     url: https://tink.uk/the-difference-between-keyboard-and-screen-reader-navigation/
     source: Léonie Watson


### PR DESCRIPTION
This PR updates the The Paciello Group’s name to TPGi, following their rebrand. Links still refer to the old `paciellogroup.com` domain, as forwarding still works.