### PR TITLE
Update Resources (browsers extensions and newsletters)

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1065,16 +1065,10 @@
 			"url": "https://www.microassist.com/about/newsletter-subscriptions/"
 		},
 		{
-			"title": "Skip Links",
-			"description": "A monthly newsletter curated by the HackerYou Web Accessibility Club",
-			"additional": "HackerYou",
-			"url": "https://mailchi.mp/9f8895e93f13/hackeryou-accessibility-club-newsletter"
-		},
-		{
 			"title": "Stark",
 			"description": "Join readers from Microsoft, QZ, Amazon, and more receiving our weekly newsletter with highly curated content and write-ups, plus Stark updates here & there.",
 			"additional": "Stark",
-			"url": "https://mailchi.mp/9f8895e93f13/hackeryou-accessibility-club-newsletter"
+			"url": "https://www.getstark.co/newsletter"
 		},
 		{
 			"title": "t12t Accessibility Newsletter",

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -333,15 +333,6 @@
 			]
 		},
 		{
-			"title": "I want to see like the colour blind",
-			"description": "Right-click on a page and select 'Experience Colour Blindness' from the context menu.",
-			"additional": "artbek",
-			"url": "https://chrome.google.com/webstore/detail/i-want-to-see-like-the-co/jebeedfnielkcjlcokhiobodkjjpbjia",
-			"browsers": [
-				"Chrome"
-			]
-		},
-		{
 			"title": "headingsMap",
 			"description": "The extension generates a documentmap or index of any web document structured with headings (you can access directly to the content by clicking on any of its items), and now, it shows the HTML 5 outline.",
 			"additional": "Rumoroso",
@@ -377,15 +368,6 @@
 			"url": "https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh",
 			"browsers": [
 				"Chrome"
-			]
-		},
-		{
-			"title": "Web Accessibility Toolbar",
-			"description": "The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.",
-			"additional": "TPGi",
-			"url": "https://developer.paciellogroup.com/resources/wat/",
-			"browsers": [
-				"Internet Explorer"
 			]
 		}
 	],

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -336,9 +336,11 @@
 			"title": "headingsMap",
 			"description": "The extension generates a documentmap or index of any web document structured with headings (you can access directly to the content by clicking on any of its items), and now, it shows the HTML 5 outline.",
 			"additional": "Rumoroso",
-			"url": "https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?hl=en",
+			"url": "https://rumoroso.bitbucket.io/,
 			"browsers": [
-				"Chrome"
+				"Chrome",
+				"Firefox",
+				"Edge"
 			]
 		},
 		{

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -336,7 +336,7 @@
 			"title": "headingsMap",
 			"description": "The extension generates a documentmap or index of any web document structured with headings (you can access directly to the content by clicking on any of its items), and now, it shows the HTML 5 outline.",
 			"additional": "Rumoroso",
-			"url": "https://rumoroso.bitbucket.io/,
+			"url": "https://rumoroso.bitbucket.io/",
 			"browsers": [
 				"Chrome",
 				"Firefox",


### PR DESCRIPTION
Hello!

Here is a quick update on browsers extensions and newsletters:
- The "I want to see like the colour blind" and the WAT extensions are not available anymore
- HeadingsMap : updated URL + browsers
- Remove a 404 link and update the link for the Stark newsletter