### PR TITLE
Rename Myth: Alternate text can be automated

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -78,3 +78,7 @@
 [[redirects]]
 	from = "/posts/2020-02-05-text-resizing-in-ios-and-android/"
 	to = "/posts/2021-02-05-text-resizing-in-ios-and-android/"
+
+[[redirects]]
+	from = "/posts/2021-03-23-myth-alternate-text-can-be-automated/"
+	to = "/posts/2021-03-23-alternate-text-and-automation/"

--- a/src/posts/2021-03-23-alternate-text-and-automation.md
+++ b/src/posts/2021-03-23-alternate-text-and-automation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Alternate text can be automated
+title: Alternate text and automation
 description: "Alternate (alt) text help people who use assistive technology understand images, and are a core part of the Web Content Accessibility Guidelines (WCAG). They require a human’s input to be effective."
 category: Myth
 author: Eric Bailey


### PR DESCRIPTION
This PR renames the post "Myth: Alternate text can be automated" to "Myth: Alternate text and automation", based on [feedback from this tweet](https://twitter.com/chandracarney/status/1374756212781240320).