### PR TITLE
Adds word-break normal in checklist code for screens below wrist-large

### DIFF
--- a/src/css/components/_c-checklist.scss
+++ b/src/css/components/_c-checklist.scss
@@ -66,6 +66,10 @@ $_checklist-padding: (
 		margin-left: 0.25ch;
 		margin-right: 0.25ch;
 		padding: 0.3ch 0.5ch;
+
+		@include mappy-bp(wrist-small wrist-large) {
+			word-break: normal;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1218 