### PR TITLE
Remove extraneous word on contributing guidelines page

### DIFF
--- a/src/contributing-guidelines.njk
+++ b/src/contributing-guidelines.njk
@@ -302,7 +302,7 @@ templateClass: template-generic
 	<ol>
 		<li>The last comment was made over three months ago.</li>
 		<li>There has been no activity since.</li>
-		<li>Someone has attempted to address the Issue, no with no followup participation from the author.</li>
+		<li>Someone has attempted to address the Issue, with no followup participation from the author.</li>
 	</ol>
 	<h4 id="stale-pull-requests" class="c-heading-small">
 		Stale Pull Requests


### PR DESCRIPTION
I didn't make an issue for this as it's really quite minor - a repeated `no` that should be removed. 