### PR TITLE
Add links to each author's posts in author blurbs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,6 +41,12 @@ module.exports = function (eleventyConfig) {
     return DateTime.fromJSDate(dateObj).toFormat('yyyy-LL-dd');
   });
 
+  eleventyConfig.addFilter("getPostsByAuthor", (posts, author) => {
+    return posts.filter(a => {
+      return a.data.author === author
+    });
+  });
+
   // only content in the `posts/` directory
   eleventyConfig.addCollection("posts", function (collection) {
     return collection.getFilteredByGlob("./src/posts/*").sort(function (a, b) {

--- a/src/_includes/person.njk
+++ b/src/_includes/person.njk
@@ -21,6 +21,12 @@
 				{{ person.biography }}
 			</p>
 		{% endif %}
+		{% set author_posts = collections.posts | getPostsByAuthor(person.name) %}
+		<ul>
+			{% for post in author_posts %}
+				<li><a class="c-person__link" href="{{post.url}}">{{post.data.title}}</a></li>
+			{% endfor %}
+		</ul>
 	{% endif %}
 	{% if personRole == "staff" %}
 		<h3 id="{{ person.name | slugify }}" class="u-font-size-body-large c-person__name">

--- a/src/css/components/content/_lists.scss
+++ b/src/css/components/content/_lists.scss
@@ -1,5 +1,5 @@
 // Namespace
-.c-content {
+.c-content, .c-person {
 	dl,
 	ul {
 		margin-left: map-get($global-post-content-inset, small);

--- a/src/css/components/content/_lists.scss
+++ b/src/css/components/content/_lists.scss
@@ -1,5 +1,6 @@
 // Namespace
-.c-content, .c-person {
+.c-content, 
+.c-person {
 	dl,
 	ul {
 		margin-left: map-get($global-post-content-inset, small);


### PR DESCRIPTION
![a screenshot of the A11y Project's website, from /authors page. There is a box with The A11Y Project Team as a heading, WEBSITE as a subheading, and caption "the maintainers who help run this site" on the line below. At the bottom there is an underlined link with a dash next to it with the title of a post called "Should I use an accessibility overlay?" ](https://user-images.githubusercontent.com/4480480/113355638-b4f56500-9306-11eb-9e4d-839abdfebbf4.png)

Closes #938. 

Very open to suggestions on styling here! 
