### PR TITLE
Use fully qualified name for eleventy in build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
 		"Wayne Elgin (https://twitter.com/esjay)"
 	],
 	"scripts": {
-		"start": "npx eleventy --watch | gulp watch",
+		"start": "npx @11ty/eleventy --watch | gulp watch",
 		"a11yproject": "npm start",
-		"publish": "npx gulp && npx eleventy",
+		"publish": "npx gulp && npx @11ty/eleventy",
 		"clean": "rm -rf ./dist",
-		"eleventy-build": "npx eleventy",
-		"eleventy-watch": "npx eleventy --watch",
-		"eleventy-debug": "DEBUG=* npx eleventy",
+		"eleventy-build": "npx @11ty/eleventy",
+		"eleventy-watch": "npx @11ty/eleventy --watch",
+		"eleventy-debug": "DEBUG=* npx @11ty/eleventy",
 		"gulp-build": "gulp",
 		"gulp-watch": "gulp watch"
 	},


### PR DESCRIPTION
Updates the build/run scripts in package.json to use the [recommended](https://www.11ty.dev/docs/usage/)`npx @11ty/eleventy` instead of just `npx eleventy`. 

This is important because of [an issue]() where if you run `npx eleventy` and don't already have Eleventy installed either locally or globally on your system, you'll fetch and run the package [eleventy](https://www.npmjs.com/package/eleventy) from npm which is not [@11ty/eleventy](https://www.npmjs.com/package/@11ty/eleventy), the static site generator. 

See [this issue in the 11ty website docs](https://github.com/11ty/11ty-website/issues/1013) and [my twitter thread](https://twitter.com/CasseyLottman/status/1379143657991892995) for more details on what can happen.
