### PR TITLE
Updating Resources for Accessible360 for consistency.

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1318,8 +1318,8 @@
 	],
 	"professionalHelp": [
 		{
-			"title": "Accessible360.com",
-			"description": "We help organizations large and small navigate their path to digital accessibility, giving more people access to their products and services.",
+			"title": "Accessible360",
+			"description": "We help organizations large and small navigate their path to digital accessibility through live-user audits, training, support and monitoring.",
 			"url": "https://accessible360.com/"
 		},
 		{
@@ -1371,7 +1371,7 @@
 	"professionalTesters": [
 		{
 			"title": "Accessible360",
-			"description": "Through audits, training, support and monitoring A360 helps organizations navigate their path to digital accessibility.",
+			"description": "We help organizations large and small navigate their path to digital accessibility through live-user audits, training, support and monitoring.",
 			"url": "https://accessible360.com/"
 		},
 		{


### PR DESCRIPTION
On the [Resources page](https://www.a11yproject.com/resources/) I noticed two references to Accessible360 with two slightly different descriptions, and one of those referencing using the company's website URL as the company name. This PR is just to tweak those two references to be identical with some updated copy for the description!