### PR TITLE
Block FLoC

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[[headers]]
+	for = "/*"
+	[headers.values]
+		Permissions-Policy = "interest-cohort=()"
 
 [[redirects]]
 	from = "/posts/how-to-hide-content/"


### PR DESCRIPTION
This PR [opts The A11Y Project out of Google's FLoC trial](https://developer.chrome.com/blog/floc/#how-can-websites-opt-out-of-the-floc-computation).