### PR TITLE
Simplify date conversions

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,12 +20,29 @@ module.exports = function (eleventyConfig) {
 
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
   eleventyConfig.addFilter('htmlDateString', (dateObj) => {
-    return DateTime.fromJSDate(dateObj).toFormat('yyyy-LL-dd');
+		return dateObj.toISOString();
   });
 
-  eleventyConfig.addFilter('dateReadable', date => {
-    return moment(date).format('LL'); // E.g. May 31, 2019
-  });
+	/**
+	 * Returns a humnan-readable date
+		E.g. May 31, 2019
+	 */
+
+  eleventyConfig.addFilter("dateReadable", (value) => {
+		const date = new Date(value);
+		const utcDate = new Date(
+			date.getUTCFullYear(),
+			date.getUTCMonth(),
+			date.getUTCDate()
+		);
+		const formatOpts = {
+			timezone: "UTC",
+			day: "numeric",
+			month: "long",
+			year: "numeric",
+		};
+		return new Intl.DateTimeFormat("en-US", formatOpts).format(utcDate);
+	});
 
   // Get the first `n` elements of a collection.
   eleventyConfig.addFilter("head", (array, n) => {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,6 @@
-const { DateTime } = require("luxon");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-const moment = require('moment');
 const slugify = require("slugify");
 const htmlmin = require("html-minifier");
 
@@ -13,10 +11,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.setDataDeepMerge(true);
 
   eleventyConfig.addLayoutAlias("post", "layouts/post.njk");
-
-  eleventyConfig.addFilter("readableDate", dateObj => {
-    return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat("dd LLL yyyy");
-  });
 
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
   eleventyConfig.addFilter('htmlDateString', (dateObj) => {
@@ -51,11 +45,6 @@ module.exports = function (eleventyConfig) {
     }
 
     return array.slice(0, n);
-  });
-
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
-  eleventyConfig.addFilter('htmlDateString', (dateObj) => {
-    return DateTime.fromJSDate(dateObj).toFormat('yyyy-LL-dd');
   });
 
   eleventyConfig.addFilter("getPostsByAuthor", (posts, author) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7596,12 +7596,6 @@
 				}
 			}
 		},
-		"luxon": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-			"integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
-			"dev": true
-		},
 		"magic-string": {
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
@@ -8147,12 +8141,6 @@
 					}
 				}
 			}
-		},
-		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-			"dev": true
 		},
 		"moo": {
 			"version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -80,11 +80,9 @@
 		"jshint-stylish": "2.2.1",
 		"kss": "^3.0.1",
 		"lazypipe": "1.0.2",
-		"luxon": "^1.26.0",
 		"markdown-it": "^12.0.6",
 		"markdown-it-anchor": "^7.1.0",
 		"markdown-it-footnote": "^3.0.2",
-		"moment": "^2.29.1",
 		"stylelint": "^13.12.0"
 	}
 }

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -40,7 +40,7 @@ templateClass: template-post
 
 			<p class="c-last-updated__body">
 				{% if updated_by %}
-					This post was last updated on <time datetime="{{ last_updated | htmlDateString }}">{{ last_updated | dateReadable }}</time> by <a href="/authors/#{{ updated_by | slugify | url }}">{{ updated_by }}</a>.
+					This post was last updated {% if last_updated %} on <time datetime="{{ last_updated | htmlDateString }}">{{ last_updated | dateReadable }}</time> {% endif %} by <a href="/authors/#{{ updated_by | slugify | url }}">{{ updated_by }}</a>.
 				{% endif %}
 				{% if thanks %}
 					{{ thanks | safe }}


### PR DESCRIPTION
This PR removes the `moment` and `Luxon` dependencies, as Node now has better date powers by way of `Intl.dateTimeFormat`.

Handling the post dates with native code causes an error if date values are not provided. My change to `post.njk` adds a check to make sure `last_updated` exists.