### PR TITLE
Strip tags from raw string before sending to slugify

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -56,7 +56,7 @@ module.exports = function (eleventyConfig) {
 
   // Universal slug filter strips unsafe chars from URLs
   eleventyConfig.addFilter("slugify", function (str) {
-    return slugify(str, {
+    return slugify(str.replace(/<\/?("[^"]*"|'[^']*'|[^>])*(>|$)/g, ''), {
       lower: true,
       replacement: "-",
       remove: /[*+~.·,()'"`´%!?¿:@»]/g


### PR DESCRIPTION
The `slugify` filter would pass entire html tags like `<code>` into its final output. This meant that the Checklist share links were much longer and complicated than they needed to be. For instance, `<code>title</code>` was converted to `-lesscodegreatertitleless/codegreater`

This change removes the `less`, `greater`, and `/` artifacts from the filter's output.