### PR TITLE
Clarify our content evaluation policy

### DIFF
--- a/src/contributing-guidelines.njk
+++ b/src/contributing-guidelines.njk
@@ -194,18 +194,37 @@ templateClass: template-generic
 		<li>Promote the post on our <a href="https://twitter.com/A11YProject">Twitter</a> and <a href="https://www.linkedin.com/company/the-a11y-project/">LinkedIn</a> social media accounts.
 		<li>Feature you in <a href="{{ '/newsletter/' | url }}">our weekly newsletter</a>.</li>
 	</ul>
+	<h3 id="evaluation" class="c-heading-medium">
+		Evaluation
+	</h3>
+	<p>
+		Acceptance of content suggestions are weighed on the quality and availability of the actual content, the accessibility of the site it is hosted on, the organization&#39;s status in the industry, and the organization&#39;s mission.
+	</p>
 	<h3 id="resources" class="c-heading-medium">
 		Resources
 	</h3>
 	<p>
-		Did you create or find a great accessibility-related resource that you think other people would find useful? Add it to the <a href="https://github.com/a11yproject/a11yproject.com/blob/main/src/_data/resources.json">Resources</a> file under the appropriate category.
+		Did you create or find a great accessibility-related resource that you think other people would find useful? Add it to the <a href="https://github.com/a11yproject/a11yproject.com/blob/main/src/_data/resources.json">Resources</a> file under the appropriate category, or <a href="{{ '/contact/' | url }}">contact us</a>.
 	</p>
 	<p>
 		Please be sure to include the resource&#39;s title, description, and a URL where it can be accessed.
 	</p>
+	<h3 id="social-media-posts" class="c-heading-medium">
+		Social media posts
+	</h3>
 	<p>
-		Acceptance of resource content suggestions are weighed on the quality of the actual content, the accessibility of the site it is hosted on, the organization&#39;s status in the industry, and the organization&#39;s mission.
+		We share links about accessibility, inclusivity, design, and development on <a href="https://twitter.com/A11YProject">Twitter</a> and <a href="https://www.linkedin.com/company/the-a11y-project/">LinkedIn</a>. If you would like to submit a link for sharing, please <a href="{{ '/contact/' | url }}">contact us</a> and include the link in your message.
 	</p>
+	<p>
+		We do not share the following:
+	</p>
+	<ul>
+		<li>Press releases,</li>
+		<li>Content hosted on sites that violate our <a href="{{ '/code-of-conduct/' | url }}">Code of Conduct</a>,</li>
+		<li>Content hosted on <a href="https://medium.com/">Medium</a>,</li>
+		<li>Content that uses a permanent accessibility overlay plugin, and</li>
+		<li>URLs with UTM codes or other <a href="{{ '/privacy-and-security/' | url }}">tracking mechanisms</a>.</li>
+	</ul>
 	<h3 id="events" class="c-heading-medium">
 		Events
 	</h3>

--- a/src/contributing-guidelines.njk
+++ b/src/contributing-guidelines.njk
@@ -198,8 +198,13 @@ templateClass: template-generic
 		Evaluation
 	</h3>
 	<p>
-		Acceptance of content suggestions are weighed on the quality and availability of the actual content, the accessibility of the site it is hosted on, the organization&#39;s status in the industry, and the organization&#39;s mission.
-	</p>
+		When we evaluate suggested content, we consider the following things:</p>
+	<ul>
+		<li>The quality of the content itself,</li>
+		<li>The accessibility of the site that hosts the content,</li>
+		<li>The content creator&lsquo;s standing within the broader web-accessibility community,</li>
+		<li>The content creator&lsquo;s mission</li>
+	</ul>
 	<h3 id="resources" class="c-heading-medium">
 		Resources
 	</h3>


### PR DESCRIPTION
This PR provides better detail about how we evaluate user-submitted content, as well as specifically naming what kinds of content we do not allow.