### PR TITLE
Use dart-sass to compile scss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,8 @@ var minify = require('gulp-cssnano');
 var gulpStylelint = require('gulp-stylelint');
 var purgeCSS = require('gulp-purgecss');
 
+sass.compiler = require('sass');
+
 // SVGs
 var svgmin = require('gulp-svgmin');
 var svgSprite = require('gulp-svg-sprite');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ var buildStyles = function (done) {
 	if (!settings.styles) return done();
 	// Run tasks on all Sass files
 	return src(paths.styles.input)
-		.pipe(sass({
+		.pipe(sass.sync({
 			outputStyle: 'expanded',
 			sourceComments: true
 		}))

--- a/src/css/components/content/_inline-content.scss
+++ b/src/css/components/content/_inline-content.scss
@@ -85,7 +85,7 @@
 	// Style guide: Components.post.pre
 	pre {
 		margin-left: map-get($global-post-content-inset, small) * -1;
-		width: calc(100% + (#{map-get($global-post-content-inset, small) * 2)}));
+		width: calc(100% + #{map-get($global-post-content-inset, small)} * 2);
 
 		// Breakpoints
 		@include mappy-bp(palm-large) {


### PR DESCRIPTION
`gulp-sass` uses `node-sass` to compile by default; this override changes that.

Changing the compiler also required me to fix some malformed scss.