### PR TITLE
Add recommended vscode settings & extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"dbaeumer.jshint",
+		"editorconfig.editorconfig",
+		"ronnidc.nunjucks",
+		"stylelint.vscode-stylelint"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"css.validate": false,
+	"scss.validate": false,
+}


### PR DESCRIPTION
The files in `.vscode` will:
- Recommend to new users some extensions related to our dev tools (currently: editoconfig, joshing, nunjucks, stylelint)
- Disable validating of CSS and SCSS files, because stylelint does that for us
