### PR TITLE
Fix typo on contribute page

### DIFF
--- a/src/contribute.njk
+++ b/src/contribute.njk
@@ -37,7 +37,7 @@ templateClass: template-contribute
 		Issues and bug fixes
 	</h2>
 	<p>
-		Is something incorrect or not working they way it should? Submitting issues is a great way to help improve the site.
+		Is something incorrect or not working the way it should? Submitting issues is a great way to help improve the site.
 	</p>
 	<p>
 		Never done something like this before? Don't worry! Open Source is all about being able to improve things for everyone by being transparent and approachable. We want to hear from you.


### PR DESCRIPTION
This PR fixes small typo on the contribute page under **Issues and bug fixes** section.

**Before**
![image](https://user-images.githubusercontent.com/52580190/128183547-7de833fc-1847-42f6-a18e-80d06c3e2d7f.png)

**After**
![image](https://user-images.githubusercontent.com/52580190/128183643-c0f2e6f6-5b3b-4110-ad4d-49d4dfb4d982.png)

Closes #1322 