### PR TITLE
Fix grammatical error on the editing section of the write-for-us page

### DIFF
--- a/src/write-for-us.njk
+++ b/src/write-for-us.njk
@@ -78,10 +78,10 @@ templateClass: template-generic
 		Provide a link to your proposed content in a format that makes it easy to comment on and suggest edits to. <a href="https://github.com/">GitHub</a>, <a href="https://www.google.com/docs/about/">Google Docs</a>, and <a href="https://www.dropbox.com/paper">Dropbox Paper</a> are services that are commonly used.
 	</p>
 	<p>
-		If you prefer not to use such a service, include your content as either an attachment or in the body of the email. If this process is used, edits will conducted via email replies.
+		If you prefer not to use such a service, include your content as either an attachment or in the body of the email. If this process is used, edits will be conducted via email replies.
 	</p>
 	<p>
-		Posts will be published when the editor is satisfied, and all criticism has been addressed. We will notify you when it is live on The A11Y Project website.
+		Posts will be published when the editor is satisfied, and all criticisms have been addressed. We will notify you when it is live on The A11Y Project website.
 	</p>
 	<h2 id="what-well-provide" class="c-heading-large">
 		What we'll provide


### PR DESCRIPTION
## About this PR

This PR corrects grammatical errors on the [editing section](https://www.a11yproject.com/write-for-us/#editing) of the write-for-us page.

## Before merging this PR:
Before merging this PR, the second and third paragraphs state:
> If you prefer not to use such a service, include your content as either an attachment or in the body of the email. If this process is used, edits will conducted via email replies.

> Posts will be published when the editor is satisfied, and all criticism has been addressed. We will notify you when it is live on The A11Y Project website.

## After merging this PR:
After merging this PR, the second and third paragraphs will state:
> If you prefer not to use such a service, include your content as either an attachment or in the body of the email. If this process is used, edits will be conducted via email replies.

> Posts will be published when the editor is satisfied, and all criticisms have been addressed. We will notify you when it is live on The A11Y Project website.

## The issue

Closes #1328 


