### PR TITLE
Fix heading text overflow on small screen on the sponsorship page

### DIFF
--- a/src/css/components/content/_headings.scss
+++ b/src/css/components/content/_headings.scss
@@ -4,6 +4,7 @@
 	h2,
 	h3 {
 		line-height: $line-height-tight;
+		overflow-wrap: break-word;
 
 		// Breakpoints
 		@include mappy-bp(lap-medium) {


### PR DESCRIPTION
## PR description

This PR will fix  text overflow on small screens on the sponsorship page.

## Before

Currently, this is what the `h1` element on the sponsorship page looks like  when viewed on small screens.
![image](https://user-images.githubusercontent.com/52580190/129455428-6afe1361-bd20-4af2-9405-15b468647b1a.png)

## After

After merging this PR,  the `h1` element on the sponsorship page will look like in the image below when viewed on small screens 
![image](https://user-images.githubusercontent.com/52580190/129455471-1f9ad364-541a-43bd-b99d-8a3c5565422d.png)

## PR

Fixes #1330 



