### PR TITLE
Fix link to Github profile of Eriol Fox

### DIFF
--- a/src/spotlight/eriol-fox.md
+++ b/src/spotlight/eriol-fox.md
@@ -9,7 +9,7 @@ further_reading:
   - title: Twitter
     url: https://twitter.com/EriolDoesDesign
   - title: GitHub
-    url: https://twitter.com/EriolDoesDesign
+    url: https://github.com/Erioldoesdesign
 eleventyNavigation:
   key: Eriol Fox
   parent: Spotlight


### PR DESCRIPTION
I noticed the link to Eriol Fox's Github was pointing to their Twitter, so I quickly fixed it.