### PR TITLE
Add job titles section to the Content Style Guide

### DIFF
--- a/src/content-style-guide.njk
+++ b/src/content-style-guide.njk
@@ -120,7 +120,7 @@ templateClass: template-generic
 		</p>
 	</div>
 	<h3 id="user-or-person-" class="c-heading-medium">
-		User or Person?
+		User or person?
 	</h3>
 	<p>
 		Prefer the terms &quot;person&quot; or &quot;people&quot; over &quot;user&quot; or &quot;users&quot;.
@@ -171,6 +171,20 @@ templateClass: template-generic
 	<p>
 		Use the terminology an individual chooses to self-identify with. Prefer <a href="https://thebodyisnotanapology.com/magazine/i-am-disabled-on-identity-first-versus-people-first-language/">identity-first language</a> if it does not conflict with an individual&#39;s expressed preferences.
 	</p>
+	<h3 id="titles" class="c-heading-medium">
+		Job titles
+	</h3>
+	<p>
+		Use the lowercase form of a job title or role unless it is in front of a name.
+	</p>
+	<div class="c-dos-donts">
+		<p>
+			<strong>Do:</strong> The A11Y Project is run with the help of its maintainers.
+		</p>
+		<p>
+			<strong>Don&#39;t:</strong> The Senior Developer scoffed at the plumber, thinking he could do better.
+		</p>
+	</div>
 	<h3 id="ableist-language" class="c-heading-medium">
 		Ableist language
 	</h3>


### PR DESCRIPTION
This PR clarifies how to treat capitalization for job titles, in order to avoid unnecessary classist distinctions. The impetus for this PR came from a conversation with @handcoding.