### PR TITLE
Update meta theme-color code

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -5,7 +5,7 @@
 		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="theme-color"
-      content="#ebf6fd"
+      content="#f6f6f6"
       media="(prefers-color-scheme: light)">
 		<meta name="theme-color"
       content="#333536"


### PR DESCRIPTION
Added some meta theme-color code that will effect the new safari-ui. This make the light-ui the light pink (LA Vibes), and the dark-ui a dark grey (nightmare!?). I thought the super bright pink with white font (current safari UI) made it hard to use, and probably failed contrast tests.

This is in response issue  that I created. #1349