### PR TITLE
Added Contrast Tools (https://contrast.tools) to Resources

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -559,11 +559,11 @@
 			"url": "https://contrast-ratio.com/"
 		},
 		{
-            "title": "Contrast Tools",
-            "description": "Test the contrast of two colors to ensure high readability using both the Advanced Perception of Color Algorithm (APCA) and the classic contrast ratio.",
-            "additional": "Protean Studio",
-            "url": "https://contrast.tools"
-        },
+			"title": "Contrast Tools",
+			"description": "Test the contrast of two colors to ensure high readability using both the Advanced Perception of Color Algorithm (APCA) and the classic contrast ratio.",
+			"additional": "Protean Studio",
+			"url": "https://contrast.tools"
+		},
 		{
 			"title": "Hex Naw",
 			"description": "Hex Naw is a tool that helps designers and developers test entire color systems for contrast and accessibility. Plug in your palette or color system and let Hex Naw do the rest.",


### PR DESCRIPTION
This PR adds [Contrast Tools](https://contrast.tools) to the "Color" section of the Resources page.

Contrast Tools makes it simple to test the contrast of two colors to ensure high readability using both the Advanced Perception of Color Algorithm (APCA) and the classic contrast ratio.