### PR TITLE
Add a reference to the Chicago Manual of Style

### DIFF
--- a/src/content-style-guide.njk
+++ b/src/content-style-guide.njk
@@ -26,7 +26,7 @@ templateClass: template-generic
 	<h2 id="general-approach" class="c-heading-large">
 		General approach
 	</h2>
-	<p>The A11Y Project uses <a href="https://www.chicagomanualofstyle.org/">the Chicago Manual of Style</a> as a foundation for this guide.</p>
+	<p>The A11Y Project follows the latest edition of <a href="https://www.chicagomanualofstyle.org"><cite>The Chicago Manual of Style</cite></a> for any grammar and style considerations that aren’t already covered here.</p>
 	<h3 id="themes" class="c-heading-medium">
 		Themes
 	</h3>

--- a/src/content-style-guide.njk
+++ b/src/content-style-guide.njk
@@ -21,11 +21,12 @@ templateClass: template-generic
 	</p>
 
 	<p>
-		A consistent writing style will help site content feel unified and aid with comprehension. Please check our <a href="{{ '/code-of-conduct/' | url }}">Code of Conduct</a> and <a href="{{ '/contributing-guidelines/' | url }}">Contributing Guidelines</a> before submitting. Questions or concerns about the Content Style Guide can be addressed in the site&#39;s <a href="https://github.com/a11yproject/a11yproject.com/issues">Issue Tracker</a>.
+		Please check our <a href="{{ '/code-of-conduct/' | url }}">Code of Conduct</a> and <a href="{{ '/contributing-guidelines/' | url }}">Contributing Guidelines</a> before submitting. Questions or concerns about the Content Style Guide can be addressed in the site&#39;s <a href="https://github.com/a11yproject/a11yproject.com/issues">Issue Tracker</a>.
 	</p>
 	<h2 id="general-approach" class="c-heading-large">
 		General approach
 	</h2>
+	<p>The A11Y Project uses <a href="https://www.chicagomanualofstyle.org/">the Chicago Manual of Style</a> as a foundation for this guide.</p>
 	<h3 id="themes" class="c-heading-medium">
 		Themes
 	</h3>


### PR DESCRIPTION
This PR adds a reference to [the Chicago Manual of Style](https://www.chicagomanualofstyle.org/) as a resource we refer to for content/grammar considerations.