### PR TITLE
Add form info as Markdown until forms are supported

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -82,3 +82,42 @@ body:
         - label: I have read, and agree to follow this project's Code of Conduct
           required: true
 ---
+
+Thank you for reporting a bug. Please fill out the following information:
+
+## Bug description
+
+> Please describe the bug you encountered. This includes the bug itself and where you encountered it.
+
+## Expected outcome
+
+> Please describe what you would expect to happen if the bug did not exist.
+
+## Steps to reproduce
+
+> Please describe the steps we can take to reproduce the bug. This will help us locate and fix it.
+
+## Technical info
+
+###  What device were you using when you encountered the bug?
+
+> Ex: phone, tablet, laptop computer, desktop computer, etc.
+
+### What operating system were you using? What version is the operating system?
+
+> Ex: macOS 11.6, etc.
+
+### What web browser were you using? What version is the web browser?
+
+> Ex: Edge 94.0.992.47
+
+### Assistive technology and version (optional)
+> Were you using any assistive technology? Examples include NVDA, VoiceOver, screen magnification, high contrast mode, etc.
+
+## Additional information
+
+> Is there anything else we should know about?
+
+## Terms
+
+[ ] I have read, and agree to follow this project's [Code of Conduct](https://www.a11yproject.com/code-of-conduct/)

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -24,3 +24,13 @@ body:
         - label: I have read, and agree to follow this project's Code of Conduct
           required: true
 ---
+
+Thank you for suggesting a feature. Please fill out the following information:
+
+## Feature suggestion
+
+> Please describe the functionality you would like to have added to the site, and why you are proposing it.
+
+## Terms
+
+[ ] I have read, and agree to follow this project's [Code of Conduct](https://www.a11yproject.com/code-of-conduct/)

--- a/.github/ISSUE_TEMPLATE/new-post.md
+++ b/.github/ISSUE_TEMPLATE/new-post.md
@@ -23,7 +23,7 @@ body:
   - type: textarea
     id: additional-information
     attributes:
-      label: Additional information
+      label: Additional information (optional)
       description: Is there anything else we should know?
   - type: checkboxes
     id: contributing-guidelines
@@ -50,3 +50,21 @@ body:
         - label: I have read, and agree to follow this project's Code of Conduct
           required: true
 ---
+
+Thank you for your interest in writing a post! Please fill out the following information:
+
+## Your idea
+
+> Please describe the post you'd like to write in 2–4 sentences, and how that post would be a good match for The A11Y Project.
+
+## Outline (optional)
+> Optionally include a proposed outline for the post.
+
+## Additional information (optional)
+
+> Is there anything else we should know?
+
+## Terms
+[ ] I have read, and agree to follow this project's [Contributing Guidelines](https://www.a11yproject.com/contributing-guidelines/)
+[ ] I have read, and agree to follow this project's [Content Style Guide](https://www.a11yproject.com/content-style-guide/)
+[ ] I have read, and agree to follow this project's [Code of Conduct](https://www.a11yproject.com/code-of-conduct/)


### PR DESCRIPTION
This PR re-adds issue content as Markdown until issue forms come out of beta.