### PR TITLE
fix: skipnav z-index

### DIFF
--- a/src/css/components/_c-skipnav.scss
+++ b/src/css/components/_c-skipnav.scss
@@ -27,21 +27,22 @@
 	letter-spacing: $font-tracking-slight;
 	padding: 1rem 2rem;
 	text-decoration: none;
-	transition:
-		background-color $animation-duration-short $animation-easing-character,
+	transition: background-color $animation-duration-short
+			$animation-easing-character,
 		color $animation-duration-short $animation-easing-character;
 
 	// States
 	&:focus {
+		z-index: 10;
 		outline: none;
 		position: absolute;
-			top: 6rem;
-			left: map-get($global-bleed, large);
+		top: 6rem;
+		left: map-get($global-bleed, large);
 
-			&:hover {
-				background-color: $color-black;
-				color: $color-white;
-			}
+		&:hover {
+			background-color: $color-black;
+			color: $color-white;
+		}
 	}
 
 	// User Queries


### PR DESCRIPTION
The skipnav was not displaying correctly when focused.

This PR adds a z-index to ensure it is displayed above the `l-hero` element.

**Before**
![CleanShot 2021-10-26 at 18 15 00@2x](https://user-images.githubusercontent.com/825855/138968697-d686ce3a-fd60-4572-bb5a-77c072e41246.png)

**After**
<img width="1255" alt="CleanShot 2021-10-26 at 18 15 24@2x" src="https://user-images.githubusercontent.com/825855/138968717-fa90f617-a966-4fdd-ae32-2f52c1bdd674.png">

