### PR TITLE
Remove Alex Brenon’s website

### DIFF
--- a/src/_data/authors.json
+++ b/src/_data/authors.json
@@ -8,7 +8,6 @@
 		},
 		{
 			"name": "Alex Brenon",
-			"website": "https://alexroseb.com/",
 			"photo": "https://pbs.twimg.com/profile_images/975451645462106112/_h6vsUym_400x400.jpg",
 			"biography": "Research Assistant for ESD and Classics at UMass Amherst. Creator of Pop-Up Astronomy."
 		},

--- a/src/_data/team.json
+++ b/src/_data/team.json
@@ -96,7 +96,6 @@
 	"alumni": [
 		{
 			"name": "Alex Brenon",
-			"website": "https://alexroseb.com/",
 			"photo": "{{ '/img/team/alex-brenon.jpg' | url }}",
 			"biography": "Research Assistant for ESD and Classics at UMass Amherst. Creator of Pop-Up Astronomy."
 		},


### PR DESCRIPTION
This PR addresses https://github.com/a11yproject/a11yproject.com/issues/1385. It removes Alex Brenon's website.