### PR TITLE
Remove Tenon from professional help

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1606,11 +1606,6 @@
 			"url": "https://www.simplyopen.io/"
 		},
 		{
-			"title": "Tenon",
-			"description": "We believe in a web accessible to everyone. Tenon.io exists because universal design is hard. We create software to help you reach beyond compliance and build superior experiences for everyone.",
-			"url": "https://tenon.io/"
-		},
-		{
 			"title": "TetraLogical",
 			"description": "We're a company with inclusion at its heart. Our focus is on emerging as well as existing technologies, offering knowledge, experience, strategic, and development services.",
 			"url": "https://tetralogical.com/"

--- a/src/posts/how-to-accessible-heading-structure.md
+++ b/src/posts/how-to-accessible-heading-structure.md
@@ -99,6 +99,7 @@ A few of the WCAG 2 AA success criteria address headings or heading structure di
 In short: use headings to describe content and use them consistently and semantically. This will help all users to better find the content they are looking for.
 
 Only WCAG 2 level **AAA** demands that headings must be structured. [Success criterion 2.4.10](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=246#section-headings) says: Section headings are used to organize the content.
+
 The worldwide web standard is **double A (AA)**, but that doesn't mean that you can't use success criteria that are triple A (AAA) if it's helpful for your users.
 
 A well-organised heading structure helps everyone, especially screen reader users, understand and navigate a web page.


### PR DESCRIPTION
This PR removes Tenon from our [professional help section](https://www.a11yproject.com/resources/#professional-help) on the Resources page, as they have been acquired by Level Access. 