### PR TITLE
Fix features resource links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,7 @@ const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const eleventyPluginTOC = require("eleventy-plugin-nesting-toc");
 
+const slugify = require("slugify");
 const htmlmin = require("html-minifier");
 
 module.exports = function (eleventyConfig) {
@@ -23,7 +24,7 @@ module.exports = function (eleventyConfig) {
 	});
 
 	/**
-	 * Returns a humnan-readable date
+	 * Returns a human-readable date
 		E.g. May 31, 2019
 	 */
 
@@ -62,6 +63,15 @@ module.exports = function (eleventyConfig) {
 	eleventyConfig.addCollection("posts", function (collection) {
 		return collection.getFilteredByGlob("./posts/*.md").sort(function (a, b) {
 			return a.date - b.date;
+		});
+	});
+
+// Universal slug filter strips unsafe chars from URLs
+	eleventyConfig.addFilter("slugify", function (str) {
+		return slugify(str.replace(/<\/?("[^"]*"|'[^']*'|[^>])*(>|$)/g, ""), {
+			lower: true,
+			replacement: "-",
+			remove: /[*+~.·,()'"`´%!?¿:@»]/g,
 		});
 	});
 

--- a/src/_includes/homepage/featured-resource.njk
+++ b/src/_includes/homepage/featured-resource.njk
@@ -1,5 +1,5 @@
 <div class="c-homepage-card">
-	<div class="c-homepage-card__image-link" onclick="location.href='/resources/{{ featuredResource.title | slugify | url }}'">
+	<div class="c-homepage-card__image-link" onclick="location.href='/resources/{{ featuredResource.title | slugify | url }}/'">
 		<img
 			class="c-homepage-card__image"
 			alt="{{ featuredResource.alt }}"
@@ -8,14 +8,14 @@
 	<p class="u-font-size-body-small u-text-transform-uppercase c-homepage-card__author">
 		{{ featuredResource.author }}
 	</p>
-	<h3 class="u-font-size-body-medium c-homepage-card__title" onclick="location.href='/resources/{{ featuredResource.title | slugify | url }}'">
+	<h3 class="u-font-size-body-medium c-homepage-card__title" onclick="location.href='/resources/{{ featuredResource.title | slugify | url }}/'">
 		{{ featuredResource.title }}
 	</h3>
 	<p class="c-homepage-card__description">
 		{{ featuredResource.description }}
 	</p>
 	<p>
-		<a class="c-homepage-card__cta" href="/resources/{{ featuredResource.title | slugify | url }}">
+		<a class="c-homepage-card__cta" href="/resources/{{ featuredResource.title | slugify | url }}/">
 			{{ featuredResource.cta }}
 		</a>
 	</p>


### PR DESCRIPTION
This PR fixes links to our featured resources. The issue was reported on our contact form from two individuals. It also restores our old `slugify` filter, as its absence was causing the announcements partial to fail to render.