### PR TITLE
Restore recent post list on homepage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,7 +61,7 @@ module.exports = function (eleventyConfig) {
 
 	// only content in the `posts/` directory
 	eleventyConfig.addCollection("posts", function (collection) {
-		return collection.getFilteredByGlob("./posts/*.md").sort(function (a, b) {
+		return collection.getFilteredByGlob("./src/posts/*.md").sort(function (a, b) {
 			return a.date - b.date;
 		});
 	});


### PR DESCRIPTION
Fixes #1404

## Summary

It looks like Eleventy was previously more forgiving about paths when doing `collectionApi.getFilteredByGlob`. As with other paths in the eleventy config, we have to explicitly include `./src/`.

## Testing

1. Go to [the homepage on the deploy preview](https://61f204b13e923900070907c0--thea11yproject.netlify.app/).
2. Scroll to the "Recent posts" section
3. Verify that three posts appear beneath the heading

<img src="https://user-images.githubusercontent.com/13525251/151282024-63de720f-04b9-4203-91c9-b5e00e03e927.png" width="400" alt="" />

