### PR TITLE
Fix #1416

### DIFF
--- a/src/css/base/_html.scss
+++ b/src/css/base/_html.scss
@@ -13,7 +13,6 @@ html {
 	line-height: $line-height-loose;
 	margin: 0;
 	min-height: 100%;
-	overflow-y: scroll;
 	padding: 0;
 	text-size-adjust: 100%;
 


### PR DESCRIPTION
This PR addresses #1416. It removes `overflow-y: scroll;` from the `html` selector. This should restore the ability for a Vimium user to interact with the site.