### PR TITLE
Implement base JS and markup for a theme toggle

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -12,6 +12,10 @@
       media="(prefers-color-scheme: dark)">
 		{% include "meta/social-media.njk" %}
 		{% include "meta/icons.njk" %}
+
+		{# This needs to run before CSS so we don't get a flash of the default theme #}
+		<script src="{{ '/js/apply-theme-setting.min.js?v=' + getCurrentVersion.version | url }}"></script>
+		
 		<link rel="stylesheet" as="style" href="{{ '/css/screen.min.css?v=' + getCurrentVersion.version  | url }}" />
 		<link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}" />
 		<link rel="sitemap" type="application/xml" title="{{ metadata.title }}" href="{{ '/sitemap.xml' | url }}" />
@@ -46,6 +50,8 @@
 		{% include "footer.njk" %}
 
 		<script async src="{{ '/js/lib/details-element-polyfill.polyfill.min.js' | url }}"></script>
+		<script src="{{ '/js/theme-toggle.min.js?v=' + getCurrentVersion.version | url }}"></script>
+
 		{% if hasToc %}
 		<script async src="{{ '/js/lib/table-of-contents.min.js' | url }}"></script>
 		{% endif %}

--- a/src/js/apply-theme-setting.js
+++ b/src/js/apply-theme-setting.js
@@ -1,0 +1,19 @@
+/**
+ * A global function that the theme toggle can use to apply the current theme.
+ * @param {string} override The setting that needs to applied or undefined
+ */
+window.applyThemeSetting = function (override) {
+	const currentSetting =
+		override || localStorage.getItem("user-color-scheme") || "system";
+	const currentThemeValue =
+		document.documentElement.getAttribute("data-user-theme");
+
+	if (currentSetting) {
+		if (currentSetting !== currentThemeValue) {
+			document.documentElement.setAttribute("data-user-theme", currentSetting);
+		}
+	}
+
+	return currentSetting;
+};
+window.applyThemeSetting();

--- a/src/js/theme-toggle.js
+++ b/src/js/theme-toggle.js
@@ -1,0 +1,65 @@
+/**
+ * A lightweight, concise theme toggle that attaches state and events to button controls
+ * with a [data-theme] attribute. When either one of these controls is clicked/tapped
+ * or the state changes via another control, the appropriate [aria-pressed] value is applied
+ */
+(function themeToggle() {
+	const buttons = document.querySelectorAll("button[data-theme]");
+	const storageKey = "user-color-scheme";
+	const currentSetting = localStorage.getItem("user-color-scheme") || "system";
+
+	/**
+	 * Grabs the passed setting value (or current setting as fallback)
+	 * and applies it where needed
+	 * @param {string} passedSetting The setting that needs to applied or undefined
+	 */
+	const applySetting = (passedSetting) => {
+		const settingToApply = passedSetting || currentSetting;
+
+		if (settingToApply) {
+			setStatus(settingToApply);
+			window.applyThemeSetting(settingToApply);
+		} else {
+			setStatus("system");
+		}
+	};
+
+	/**
+	 * Loop the buttons and set aria-pressed (active) state depending on current theme
+	 * @param {string} passedSetting The setting that needs to applied or undefined
+	 */
+	const setStatus = (currentSetting) => {
+		buttons.forEach((button) => {
+			button.setAttribute(
+				"aria-pressed",
+				currentSetting === button.getAttribute("data-theme") ? "true" : "false"
+			);
+		});
+	};
+
+	// Set the initial state of the controls, prior to interaction
+	setStatus(currentSetting);
+
+	// Attach a click event to each button that grabs its [data-theme]
+	// attribute and transmits that to the theme application script (in the head)
+	// and sends it to the setStatus to apply the correct aria roles.
+	buttons.forEach((button) => {
+		button.addEventListener("click", (evt) => {
+			evt.preventDefault();
+
+			const setting = button.getAttribute("data-theme");
+
+			applySetting(setting);
+
+			// We use a switch here because if system is selected, we clear out local storage
+			switch (setting) {
+				case "system":
+					localStorage.removeItem(storageKey);
+					break;
+				default:
+					localStorage.setItem(storageKey, setting);
+					break;
+			}
+		});
+	});
+})();

--- a/src/js/theme-toggle.js
+++ b/src/js/theme-toggle.js
@@ -4,7 +4,9 @@
  * or the state changes via another control, the appropriate [aria-pressed] value is applied
  */
 (function themeToggle() {
-	const buttons = document.querySelectorAll("button[data-theme]");
+	const controls = document.querySelectorAll(
+		"[data-theme-toggle] [role='switch']"
+	);
 	const storageKey = "user-color-scheme";
 	const currentSetting = localStorage.getItem("user-color-scheme") || "system";
 
@@ -25,29 +27,29 @@
 	};
 
 	/**
-	 * Loop the buttons and set aria-pressed (active) state depending on current theme
-	 * @param {string} passedSetting The setting that needs to applied or undefined
+	 * Loop the controls and set checked state depending on current theme
+	 * @param {string} currentSetting The setting that needs to applied or undefined
 	 */
 	const setStatus = (currentSetting) => {
-		buttons.forEach((button) => {
-			button.setAttribute(
-				"aria-pressed",
-				currentSetting === button.getAttribute("data-theme") ? "true" : "false"
-			);
+		controls.forEach((control) => {
+			control.checked = currentSetting === control.value;
 		});
 	};
 
 	// Set the initial state of the controls, prior to interaction
 	setStatus(currentSetting);
 
-	// Attach a click event to each button that grabs its [data-theme]
-	// attribute and transmits that to the theme application script (in the head)
-	// and sends it to the setStatus to apply the correct aria roles.
-	buttons.forEach((button) => {
-		button.addEventListener("click", (evt) => {
-			evt.preventDefault();
+	// Attach a change event to each control that grabs its value
+	// and transmits that to the theme application script (in the head)
+	// then sends it to the setStatus to apply the correct aria roles.
+	controls.forEach((control) => {
+		control.addEventListener("change", () => {
+			// We don't need to process if not checked
+			if (!control.checked) {
+				return;
+			}
 
-			const setting = button.getAttribute("data-theme");
+			const setting = control.value;
 
 			applySetting(setting);
 

--- a/src/theme-toggle-playground.njk
+++ b/src/theme-toggle-playground.njk
@@ -7,14 +7,23 @@ title: 'Theme toggle playground'
 <div class="l-content c-content c-content--generic">
   <h1>Theme toggle</h1>
   <p>This is just a temporary page to give you an area to work on the theme toggle away from most of the other site.</p>
-  <div class="theme-toggle">
+  <div data-theme-toggle>
     <!-- I'm just using a heading here, but label these however it works best in context -->
     <h2>Colour theme</h2>
 
-    <!-- These are your main controls. The aria-pressed role is determined by the current active theme. 
+    <!-- These are your main controls. The checked state is determined by the current active theme. 
          System is selected by default. -->
-    <button data-theme="system" aria-pressed="true">System</button>
-    <button data-theme="light" aria-pressed="false">Light</button>
-    <button data-theme="dark" aria-pressed="false">Dark</button>
+    <label>
+      <input name="theme" value="system" type="radio" role="switch" checked />
+      System
+    </label>
+    <label>
+      <input name="theme" value="light" type="radio" role="switch" />
+      Light 
+    </label>
+    <label>
+      <input name="theme" value="dark" type="radio" role="switch" />
+      Dark 
+    </label>
   </div>
 </div>

--- a/src/theme-toggle-playground.njk
+++ b/src/theme-toggle-playground.njk
@@ -1,0 +1,20 @@
+---
+layout: layouts/home.njk
+templateClass: template-generic
+title: 'Theme toggle playground' 
+---
+
+<div class="l-content c-content c-content--generic">
+  <h1>Theme toggle</h1>
+  <p>This is just a temporary page to give you an area to work on the theme toggle away from most of the other site.</p>
+  <div class="theme-toggle">
+    <!-- I'm just using a heading here, but label these however it works best in context -->
+    <h2>Colour theme</h2>
+
+    <!-- These are your main controls. The aria-pressed role is determined by the current active theme. 
+         System is selected by default. -->
+    <button data-theme="system" aria-pressed="true">System</button>
+    <button data-theme="light" aria-pressed="false">Light</button>
+    <button data-theme="dark" aria-pressed="false">Dark</button>
+  </div>
+</div>


### PR DESCRIPTION
This addition adds a markup pattern—radio buttons—and some lightweight JavaScript that gets and sets a `user-color-scheme` localStorage value based on their state. 

This state is then applied in two places:

1) As a `data-user-theme` value on the HTML root element 
2) As a `checked` state on the corresponding radio button control

Every time this state changes, the data is saved in localStorage. When a page is loaded with the `apply-theme-setting.min.js` script in the `<head>` *before* the CSS is loaded, the correct theme via localStorage will be applied.

The default theme is system. The intent of that is that the user’s preference will be honoured.

![A browser with dev tools showing the radio buttons and the user-color-scheme attribute on the html root. Arrows and boxes demonstrate the relationship.](https://user-images.githubusercontent.com/8672583/158205412-6bdbe282-757a-46f2-a917-f72dd3d7055d.png)

I've added a temporary page that features the new HTML controls. This is to hopefully make your lives easier when it comes to applying the CSS. 
