### PR TITLE
fix: gaming heading id

### DIFF
--- a/src/resources.njk
+++ b/src/resources.njk
@@ -37,7 +37,7 @@ templateClass: template-resources
 	</div>
 
 	{% set resourceType = "Gaming" %}
-	<h3 id="books" class="c-heading-medium u-spacing-top-long">
+	<h3 id="gaming" class="c-heading-medium u-spacing-top-long">
 		{{ resourceType }}
 	</h3>
 	<p class="c-preface">


### PR DESCRIPTION
I was just browing the [Resources](https://www.a11yproject.com/resources/) page and realised that the "Gaming" link incorrectly points to the "Books" section. This fixes that.