### PR TITLE
Fix  article redirect error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -221,7 +221,7 @@
 
 [[redirects]]
 	from = "/posts/2013-05-11-skip-nav-links/"
-	to = "/posts/posts/skip-nav-links/"
+	to = "/posts/skip-nav-links/"
 
 [[redirects]]
 	from = "/posts/2021-08-25-starting-a-design-with-accessibility/"


### PR DESCRIPTION
This PR redirects from https://www.a11yproject.com/posts/2013-05-11-skip-nav-links/ to https://www.a11yproject.com/posts/skip-nav-links/ instead of https://www.a11yproject.com/posts/posts/skip-nav-links/ which doesn't exist.

Fixes #1431 