### PR TITLE
Uses type=radio in theme toggle JS code

### DIFF
--- a/src/js/theme-toggle.js
+++ b/src/js/theme-toggle.js
@@ -5,7 +5,7 @@
  */
 (function themeToggle() {
 	const controls = document.querySelectorAll(
-		"[data-theme-toggle] [role='switch']"
+		"[data-theme-toggle] [type='radio']"
 	);
 	const storageKey = "user-color-scheme";
 	const currentSetting = localStorage.getItem("user-color-scheme") || "system";


### PR DESCRIPTION
When I removed role="switch" the JS code for the switching stopped working properly. I have updated the JS code to use `type='radio'` instead of `role='switch'`