### PR TITLE
Adds a checkbox suffix in checklist item checkboxes

### DIFF
--- a/src/_includes/checklist__task.njk
+++ b/src/_includes/checklist__task.njk
@@ -9,9 +9,9 @@
 	<div class="c-checklist__checkbox">
 		<input
 			type="checkbox"
-			name="{{ task.checkboxId }}"
-			id="{{ task.checkboxId }}">
-		<label for="{{ task.checkboxId }}">
+			name="{{ task.checkboxId }}-checkbox"
+			id="{{ task.checkboxId }}-checkbox">
+		<label for="{{ task.checkboxId }}-checkbox">
 			<span class="u-hide-visually">Task: {{ task.title | safe }}</span>
 		</label>
 	</div>


### PR DESCRIPTION
Fixes #1441 

Adds a `-checkbox` suffix to the checkbox input element ids to prevent ids of the input element and the details-summary part to collide with each other.