### PR TITLE
Add Eleventy generator meta info

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -4,6 +4,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="generator" content="{{ eleventy.generator }}">
 		<meta name="theme-color"
       content="#f6f6f6"
       media="(prefers-color-scheme: light)">

--- a/src/posts/should-i-use-an-accessibility-overlay.md
+++ b/src/posts/should-i-use-an-accessibility-overlay.md
@@ -59,6 +59,9 @@ further_reading:
   - title: "Exhibit A for 21-cv-00017: Sole reliance on accessiBe will not be sufficient in ensuring full and equal access to a website"
     url: https://www.scribd.com/document/490740167/Exhibit-A-for-21-cv-00017
     source: Scribd
+  - title: "For Blind Internet Users, the Fix Can Be Worse Than the Flaws"
+    url: https://www.nytimes.com/2022/07/13/technology/ai-web-accessibility.html
+    source: The New York Times
   - title: "Honor the ADA: Avoid Web Accessibility Quick-Fix Overlays"
     url: https://www.lflegal.com/2020/08/quick-fix/
     source: Lainey Feingold


### PR DESCRIPTION
This PR adds a `meta` tag to allow the site to [programmatically  express that it is built using Eleventy](https://darn.es/you-should-add-a-generator-tag-to-your-eleventy-site/).