### PR TITLE
Add The Neurodivergent Woman Podcast

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1619,6 +1619,13 @@
 			"type": "Episode"
 		},
 		{
+			"title": "The Neurodivergent Woman",
+			"description": "A podcast for neurodivergent women, covering Autism to ADHD and everything in between. Monique and Michelle aim to educate and inspire women who think differently.",
+			"additional": "Monique Mitchelson and Michelle Livock",
+			"url": "https://www.ndwomanpod.com/",
+			"type": "Podcast"
+		},
+		{
 			"title": "Presentable 30: Accessibility is Social Justice",
 			"description": "This week on the show, we talk to Laura Kalbag about her new book, Accessibility for Everyone. We discuss how digital products have an increasing mandate to be broadly usable by everyone in society, and what we can do to achieve better accessibility in our designs.",
 			"additional": "Presentable",


### PR DESCRIPTION
I've been trying to understand more about neurodiverse people, and [The Neurodivergent Woman](https://www.ndwomanpod.com/) was shared at work yesterday.

We don't have any podcast that cover neurodiversity in tech. And unfortunately this isn't one.

It's is as close as it gets though, as they walk us through different conditions and user needs. 

But if we're restricting to tech only, then perfectly happy for it to be excluded :) 