### PR TITLE
Fix Spotlight detail page table of contents

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1621,17 +1621,17 @@
 			"type": "Podcast"
 		},
 		{
-			"title": "Command Z Podcast - Episodio 73: Adriana Mattei Sosa | Diseño Accesible (Spanish)",
-			"description": "Aprende sobre la diversidad de diseños del bastón, herramienta para personas con impedimento visual. Comprende cómo los diseñadores podemos crear experiencias inclusivas y centradas en el diseño universal. Escucha como la disciplina del diseño resuelve problemas que son desapercibidos ante la falta de educación y empatía hacia la comunidad con discapacidad.",
-			"additional": "Adriana Mattei Sosa",
-			"url": " https://podcasts.apple.com/us/podcast/episodio-86-ivonne-acevedo-accesibilidad-sin-barreras/id1464454956?i=1000514246627",
+			"title": "Command Z Podcast - Episodio 86: Ivonne Acevedo | Accesibilidad sin barreras (Spanish)",
+			"description": "Escucha la importancia del diseño universal en proyectos arquitectónicos.Aprende sobre conceptos básicos de la accesibilidad digitalVisualiza como tú puedes aportar mediante tus diseños la accesibilidad y diversidad que todos necesitamos.",
+			"additional": "Ivonne Acevedo",
+			"url": "https://podcasts.apple.com/us/podcast/episodio-86-ivonne-acevedo-accesibilidad-sin-barreras/id1464454956?i=1000514246627",
 			"type": "Episode"
 		},
 		{
 			"title": "Command Z Podcast - Episodio 77: Paula Goyanes | Accesibilidad & Development (Spanish)",
 			"description": "Escucha cómo crear diseños accesibles y cómo llevarlos a producción de una manera correcta. Aprende como el diseño y el development trabajan de la mano para crear experiencias accesibles.Conoce como hacer experiencias usables y accesibles incluso para motores de búsqueda y mejorar tu SEO.",
 			"additional": "Paula Goyanes",
-			"url": " https://podcasts.apple.com/us/podcast/episodio-77-paula-goyanes-accesibilidad-development/id1464454956?i=1000505332708",
+			"url": "https://podcasts.apple.com/us/podcast/episodio-77-paula-goyanes-accesibilidad-development/id1464454956?i=1000505332708",
 			"type": "Episode"
 		},
 		{

--- a/src/css/vendor/_v-toc.scss
+++ b/src/css/vendor/_v-toc.scss
@@ -2,6 +2,8 @@
 // http://github.com/cferdinandi/table-of-contents
 .v-toc {
 	margin-right: 2rem;
+	position: relative;
+	z-index: z(component);
 
 	// States
 	&[open] {


### PR DESCRIPTION
This PR addresses a bug on our Spotlight detail pages where the Table of Contents could not be clicked on to expand/collapse it. The issue was reported via our contact form.