### PR TITLE
Update footer links

### DIFF
--- a/src/_includes/nav/footer.njk
+++ b/src/_includes/nav/footer.njk
@@ -66,10 +66,10 @@
 				<a class="c-footer__link" href="{{ '/contact/' | url }}">Contact</a>
 			</li>
 			<li>
-				<a class="c-footer__link" href="https://twitter.com/A11YProject">Twitter</a>
+				<a class="c-footer__link" href="https://a11y.info/@thea11yproject/">Mastodon</a>
 			</li>
 			<li>
-				<a class="c-footer__link" href="https://www.linkedin.com/company/the-a11y-project/">LinkedIn</a>
+				<a class="c-footer__link" href="https://twitter.com/A11YProject">Twitter</a>
 			</li>
 			<li>
 				<a class="c-footer__link" href="{{ '/newsletter/' | url }}">Newsletter</a>

--- a/src/github.njk
+++ b/src/github.njk
@@ -1,8 +1,8 @@
 ---
 eleventyNavigation:
-  key: Project Roadmap
+  key: GitHub
   parent: Support
   order: 5
-  url: https://github.com/a11yproject/a11yproject.com/projects/1
+  url: https://github.com/a11yproject/a11yproject.com
 permalink: false
 ---


### PR DESCRIPTION
This PR:

- Removes a link to our LinkedIn presence,
- Adds a link to Mastodon, and
- Updates our GitHub link to point away from our Projects page and links to our repo's main landing page instead.

Our Projects page is not working as intended and will be deprecated at a later date. See https://github.com/a11yproject/a11yproject.com/issues/1497.