### PR TITLE
Updates copyright year to 2023.

### DIFF
--- a/src/_includes/nav/copyright-back-to-top.njk
+++ b/src/_includes/nav/copyright-back-to-top.njk
@@ -1,6 +1,6 @@
 <div class="l-footer__copyright">
 	<p class="c-font-size-body-small">
-  	&copy; 2013–2022 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. <a class="c-footer__copyright-link" href="{{ '/sitemap.xml' | url }}">Sitemap</a>.
+  	&copy; 2013–2023 The Accessibility Project. <a class="c-footer__copyright-link" href="https://www.apache.org/licenses/LICENSE-2.0"><abbr>APLv2</abbr></a>. <a class="c-footer__copyright-link" href="{{ '/sitemap.xml' | url }}">Sitemap</a>.
 	</p>
 	<p class="c-footer__copyright">
 		Powered by <a class="c-footer__copyright-link" href="https://www.11ty.io/">Eleventy</a>, <a class="c-footer__copyright-link" href="https://www.netlify.com/">Netlify</a>, and <a class="c-footer__copyright-link" href="https://github.com/a11yproject/a11yproject.com">GitHub</a>.


### PR DESCRIPTION
@ericwbailey - Updating copyright year in copyright-back-to-top.njk to reflect the current year (2023).