### PR TITLE
Update repo for mgifford's course list

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -801,7 +801,7 @@
 			"title": "Accessibility Courses",
 			"description": "Courses, webinars, educational videos, and more, offered in web accessibility.",
 			"additional": "Mike Gifford",
-			"url": "https://github.com/mgifford/a11y-courses"
+			"url": "https://github.com/accessibility/a11y-courses"
 		},
 		{
 			"title": "Accessibility fundamentals",


### PR DESCRIPTION
The origina repo https://github.com/mgifford/a11y-courses points to a new repo, so I have updated accordingly.

<img width="943" alt="image" src="https://user-images.githubusercontent.com/4522927/221171351-d077d02a-15a5-4b9a-8ffc-8a60c8c225fc.png">
