### PR TITLE
Fix Newsletter signup page reflow issue

### DIFF
--- a/src/css/components/_c-form.scss
+++ b/src/css/components/_c-form.scss
@@ -151,3 +151,8 @@ $_c-input-margin-top: 1.5rem;
 	margin-top: 0;
 	padding-left: 1rem;
 }
+
+
+.c-form__legal {
+	margin-top: 0.25rem !important;
+}

--- a/src/newsletter.njk
+++ b/src/newsletter.njk
@@ -14,7 +14,7 @@ templateClass: template-simple
 			{{ title }}
 		</h1>
 		<p>
-			{{ subtitle }} You can <a href="https://buttondown.email/the-a11y-project/archive/the-a11y-project-update-february-5th-2021/">read a sample issue here</a>.
+			{{ subtitle }} <a href="https://buttondown.email/the-a11y-project/archive/the-a11y-project-update-february-5th-2021/">Read a sample issue</a>.
 		</p>
 
 		<form
@@ -37,7 +37,10 @@ templateClass: template-simple
 				name="email"
 				required />
 			<input type="hidden" value="1" name="embed"></input>
-			<input onclick="handleFormSubmit(event)" class="c-form__button" type="submit" value="Subscribe (Opens in a new tab)"></input>
+			<input aria-describedby="instructions-new-tab" onclick="handleFormSubmit(event)" class="c-form__button" type="submit" value="Subscribe"></input>
+			<p id="instructions-new-tab" class="u-font-size-body-small c-form__legal">
+				Opens in a new tab.
+			</p>
 			<p>
 				<a class="u-font-size-body-small c-form__vendor" href="https://buttondown.email">Powered by Buttondown.</a>
 			</p>


### PR DESCRIPTION
This PR addresses an issue with [our Newsletter page](https://www.a11yproject.com/newsletter/). It ensures the content reflows on smaller viewports by moving the (opens in a new tab) instructions out of the submit button, then associates it via `aria-describedby`.