### PR TITLE
Add note about supported payment types

### DIFF
--- a/src/contributing-guidelines.njk
+++ b/src/contributing-guidelines.njk
@@ -95,6 +95,9 @@ templateClass: template-generic
 		<li>Promote the post on our <a href="https://twitter.com/A11YProject">Twitter</a> and <a href="https://www.linkedin.com/company/the-a11y-project/">LinkedIn</a> social media accounts.
 		<li>Feature you in <a href="{{ '/newsletter/' | url }}">our weekly newsletter</a>.</li>
 	</ul>
+	<p>
+		Payment is coordinated via email, using PayPal, Venmo, or Square Cash. We no longer support bank transfers due to attempts at scamming.
+	</p>
 	<h4 id="translation" class="c-heading-small">
 		Translation
 	</h4>

--- a/src/write-for-us.njk
+++ b/src/write-for-us.njk
@@ -91,7 +91,7 @@ templateClass: template-generic
 		<li>
 			<strong>Compensation.</strong> We value and respect your opinions and expertise. As such, we can offer payment for published content. Each post that has been reviewed and published will be paid $75.00 USD.
 			<ul>
-				<li>Payment will be conducted via PayPal. We are also willing to use other services, should circumstances require it.</li>
+				<li>Payment will be conducted via PayPal, Venmo, or Cash app</li>
 				<li>If you prefer, payment can be issued to a nonprofit of your choice instead. We will provide a receipt.</li>
 			</ul>
 		</li>


### PR DESCRIPTION
This PR explicitly lists out our supported method of payments, as well as mentions why we no longer support bank transfers.