### PR TITLE
Remove the Contact page

### DIFF
--- a/src/_includes/nav/footer.njk
+++ b/src/_includes/nav/footer.njk
@@ -63,9 +63,6 @@
 		</h2>
 		<ul class="c-footer__list">
 			<li>
-				<a class="c-footer__link" href="{{ '/contact/' | url }}">Contact</a>
-			</li>
-			<li>
 				<a class="c-footer__link" href="https://a11y.info/@thea11yproject/">Mastodon</a>
 			</li>
 			<li>

--- a/src/write-for-us.njk
+++ b/src/write-for-us.njk
@@ -69,7 +69,7 @@ templateClass: template-generic
 		If you do not have a GitHub account
 	</h3>
 	<p>
-		<a href="{{ '/contact/' | url }}">Contact us</a> with a suitable message that indicates the kind of content you are pitching.
+		Contact us with a suitable message that indicates the kind of content you are pitching.
 	</p>
 	<h3 id="editing" class="c-heading-medium">
 		Editing


### PR DESCRIPTION
This PR removes the Contact page. All it really does is collect scams, grifts, backlink schemes, and other unwanted and undesirable messages and I don't want to burden anyone else with that exhausting nonsense.