### PR TITLE
Fix broken link to web-a11y Slack post on TPGI website

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -673,7 +673,7 @@
 		{
 			"title": "Anybody can be an A11y Slacker",
 			"description": "Information on the web-a11y Slack group.",
-			"url": "https://developer.paciellogroup.com/blog/2015/07/anybody-can-be-an-a11y-slacker/"
+			"url": "https://www.tpgi.com/anybody-can-be-an-a11y-slacker/"
 		},
 		{
 			"title": "CivicActions Accessibility Practice Area Site",


### PR DESCRIPTION
The previous link redirects to https://www.tpgi.com/development/, which isn’t super helpful. TPGi is the new name of the Paciello Group.