### PR TITLE
fix(posts): how-to-hide-content - Mention .sr-only

### DIFF
--- a/src/posts/how-to-hide-content.md
+++ b/src/posts/how-to-hide-content.md
@@ -53,7 +53,7 @@ With modern browsers and IE9 and up, the visually hidden selector can be written
 
 This will ensure that if an interactive element receives focus, the styles of the .`visually-hidden` class will be undone and the focusable content will be exposed.
 
-The CSS class `.visually-hidden` is also commonly known as `.sr-only`, where sr stands for "screen readers".
+Many popular CSS frameworks provide a `.visually-hidden` or `.sr-only` class, where `sr` stands for "screen readers".
 
 
 ## Alternatives to `display: none`

--- a/src/posts/how-to-hide-content.md
+++ b/src/posts/how-to-hide-content.md
@@ -41,7 +41,6 @@ The "clip pattern" accomplishes this task for you; hide the content visually, ye
 }
 ```
 
-
 If the `.visually-hidden` class is applied to natively focusable elements (such as `a`, `button`, `input`, etc) they **must** become visible when they receive keyboard focus. Otherwise, a sighted keyboard user would have to try and figure out where their visible focus indicator had gone to.
 
 With modern browsers and IE9 and up, the visually hidden selector can be written like so:

--- a/src/posts/how-to-hide-content.md
+++ b/src/posts/how-to-hide-content.md
@@ -41,6 +41,7 @@ The "clip pattern" accomplishes this task for you; hide the content visually, ye
 }
 ```
 
+
 If the `.visually-hidden` class is applied to natively focusable elements (such as `a`, `button`, `input`, etc) they **must** become visible when they receive keyboard focus. Otherwise, a sighted keyboard user would have to try and figure out where their visible focus indicator had gone to.
 
 With modern browsers and IE9 and up, the visually hidden selector can be written like so:
@@ -52,6 +53,8 @@ With modern browsers and IE9 and up, the visually hidden selector can be written
 ```
 
 This will ensure that if an interactive element receives focus, the styles of the .`visually-hidden` class will be undone and the focusable content will be exposed.
+
+The CSS class `.visually-hidden` is also commonly known as `.sr-only`, where sr stands for "screen readers".
 
 
 ## Alternatives to `display: none`


### PR DESCRIPTION
Hi team! (cc @davatron5000)

I've updated the post [How-to: Hide content](https://www.a11yproject.com/posts/how-to-hide-content/).

- fix(posts): how-to-hide-content - Mention .sr-only

Why? Personally, instead of `.visually-hidden`, I name the CSS class `.sr-only` because:
- it's shorter and quicker to write and spell.
- It's also popular among CSS libraries, such as Bootstrap, Bulma, Tailwind, (and overall Google search).

For that reason, I think it's important to mention that alternative in your post. What do you think?

Thank you :)