### PR TITLE
feat: incorporate variables into existing spacing utility classes

### DIFF
--- a/src/css/base/_all.scss
+++ b/src/css/base/_all.scss
@@ -7,7 +7,7 @@
 *::before,
 *::after {
 	box-sizing: border-box;
-	margin: 0;
-	padding: 0;
+	margin: $m-0;
+	padding: $p-0;
 	vertical-align: baseline;
 }

--- a/src/css/base/_html.scss
+++ b/src/css/base/_html.scss
@@ -11,9 +11,9 @@ html {
 	font-size: $global-type-size;
 	font-weight: $font-weight-regular;
 	line-height: $line-height-loose;
-	margin: 0;
+	margin: $m-0;
 	min-height: 100%;
-	padding: 0;
+	padding: $p-0;
 	text-size-adjust: 100%;
 
 	// Typography
@@ -39,7 +39,7 @@ html {
 
 	// Media Queries
 	@media screen and (-webkit-min-device-pixel-ratio: 2),
-	screen and (min-resolution: 2dppx) {
+		screen and (min-resolution: 2dppx) {
 		/* stylelint-disable-next-line property-no-unknown */
 		font-smoothing: subpixel-antialiased; // Only apply to devices that support font smoothing: https://www.zachleat.com/web/font-smooth/
 	}

--- a/src/css/base/_resets.scss
+++ b/src/css/base/_resets.scss
@@ -4,17 +4,14 @@
 //
 // Styleguide Base.resets
 
-
 a img {
 	border: none; // Removes borders from linked images
 }
-
 
 abbr[title],
 dfn[title] {
 	cursor: help; // Give a help cursor to elements that give extra info on `:hover`.
 }
-
 
 b,
 strong {
@@ -26,7 +23,6 @@ strong {
 	}
 }
 
-
 button,
 input[type="button"] {
 	border: 0;
@@ -34,10 +30,9 @@ input[type="button"] {
 	// Vendor
 	&::-moz-focus-inner {
 		border: 0;
-		padding: 0;
+		padding: $p-0;
 	}
 }
-
 
 em,
 cite,
@@ -52,7 +47,6 @@ i {
 	}
 }
 
-
 iframe,
 object,
 audio,
@@ -60,7 +54,6 @@ video,
 canvas {
 	@include responsify();
 }
-
 
 img,
 figure,
@@ -79,7 +72,6 @@ picture {
 	// TODO: Broken images fallback: https://bitsofco.de/styling-broken-images/
 }
 
-
 h1,
 h2,
 h3,
@@ -94,7 +86,6 @@ ins {
 	text-decoration: none;
 }
 
-
 // Selects all content in a read-only input field
 input:not([type="button"]):not([type="checkbox"]):not([type="radio"]),
 textarea {
@@ -103,11 +94,9 @@ textarea {
 	}
 }
 
-
 label {
 	cursor: pointer;
 }
-
 
 // Prevent zooming on mobile viewports when tapped
 input[type="text"],
@@ -134,7 +123,6 @@ mark {
 	@include var(color, mark-text);
 }
 
-
 sub {
 	text-transform: lowercase;
 	font-size: inherit;
@@ -146,7 +134,9 @@ sub {
 		-webkit-font-feature-settings: "subs", "subs";
 		font-feature-settings: "subs", "subs";
 
-		@supports ((-webkit-font-feature-settings: "subs") or (font-feature-settings: "subs")) {
+		@supports (
+			(-webkit-font-feature-settings: "subs") or (font-feature-settings: "subs")
+		) {
 			vertical-align: baseline;
 		}
 
@@ -156,7 +146,6 @@ sub {
 		}
 	}
 }
-
 
 sup {
 	text-transform: lowercase;
@@ -168,7 +157,9 @@ sup {
 		-webkit-font-feature-settings: "sups", "sups";
 		font-feature-settings: "sups", "sups";
 
-		@supports ((-webkit-font-feature-settings: "sups") or (font-feature-settings: "sups")) {
+		@supports (
+			(-webkit-font-feature-settings: "sups") or (font-feature-settings: "sups")
+		) {
 			vertical-align: baseline;
 		}
 
@@ -177,7 +168,6 @@ sup {
 		}
 	}
 }
-
 
 // Remove default table spacing
 table {
@@ -222,7 +212,6 @@ table {
 	}
 
 	tbody {
-
 		tr {
 			th {
 				font-weight: $font-weight-regular;
@@ -231,12 +220,10 @@ table {
 	}
 }
 
-
 textarea {
 	overflow: auto;
 	resize: vertical;
 }
-
 
 time {
 	font-variant-numeric: tabular-nums;
@@ -260,7 +247,10 @@ time {
 	/* stylelint-disable-next-line property-no-vendor-prefix */
 	-ms-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
 
-	@supports not ((-webkit-font-feature-settings: "onum" inherit) or (font-feature-settings: "onum" inherit)) {
+	@supports not (
+		(-webkit-font-feature-settings: "onum" inherit) or
+			(font-feature-settings: "onum" inherit)
+	) {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
 		font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
@@ -269,13 +259,15 @@ time {
 	/* stylelint-disable-next-line property-no-vendor-prefix, declaration-block-no-duplicate-properties */
 	-ms-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
 
-	@supports not ((-webkit-font-feature-settings: "onum" inherit) or (font-feature-settings: "onum" inherit)) {
+	@supports not (
+		(-webkit-font-feature-settings: "onum" inherit) or
+			(font-feature-settings: "onum" inherit)
+	) {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
 		font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
 	}
 }
-
 
 var {
 	font-style: normal;

--- a/src/css/components/_c-a11y-summary.scss
+++ b/src/css/components/_c-a11y-summary.scss
@@ -23,8 +23,8 @@
 }
 
 .c-a11y-summary__explanation {
-	margin-top: 0;
-	margin-bottom: 0;
+	margin-top: $mt-0;
+	margin-bottom: $mb-0;
 	text-align: center;
 
 	// Breakpoints
@@ -74,7 +74,7 @@
 .c-a11y-summary__mission {
 	font-family: $font-family-secondary;
 	font-size: $font-size-body;
-	margin-top: 2rem;
+	margin-top: $mt-4;
 	max-width: 40ch;
 	text-align: center;
 

--- a/src/css/components/_c-banner.scss
+++ b/src/css/components/_c-banner.scss
@@ -1,6 +1,5 @@
 $_banner-triangle-size: 1.49rem;
 
-
 .c-banner {
 	@include var(background-color, card-accent);
 	background-image: url("#{$path-to-img}/resource-banner-inset-lightmode.svg");
@@ -10,7 +9,7 @@ $_banner-triangle-size: 1.49rem;
 	font-family: $font-family-secondary;
 	letter-spacing: $font-tracking-slight;
 	line-height: $line-height-single;
-	margin-top: 1.5rem;
+	margin-top: $mt-3;
 	padding: 0.1rem 1rem 0.6rem 0.3rem;
 
 	// [1] Magic number to position the triangle
@@ -26,28 +25,28 @@ $_banner-triangle-size: 1.49rem;
 		right: 0.275rem; // [1]
 		z-index: -1;
 
-			// User Queries
+		// User Queries
 		@media screen and (-ms-high-contrast: active) {
 			display: none;
 		}
 	}
 
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-user-theme="light"]) & {
+	@media (prefers-color-scheme: dark) {
+		:root:not([data-user-theme="light"]) & {
 			background-image: url("#{$path-to-img}/resource-banner-inset-darkmode.svg");
-    }
-  }
+		}
+	}
 
-  [data-user-theme="dark"] &  {
+	[data-user-theme="dark"] & {
 		background-image: url("#{$path-to-img}/resource-banner-inset-darkmode.svg");
-  }
+	}
 
 	// Contexts
 	&.c-banner--resource {
 		@include var(background-color, featured-card-accent);
 		background-image: none;
 		@include var(color, featured-card-accent-text);
-		margin-top: 0;
+		margin-top: $mt-0;
 
 		&::before {
 			@include var(border-right-color, featured-card-accent-shadow);
@@ -56,10 +55,9 @@ $_banner-triangle-size: 1.49rem;
 
 	&.c-banner--post {
 		background-image: none;
-		margin-top: 0;
+		margin-top: $mt-0;
 	}
 }
-
 
 .c-banner__icon {
 	fill: currentColor;

--- a/src/css/components/_c-card-resource.scss
+++ b/src/css/components/_c-card-resource.scss
@@ -7,10 +7,10 @@
 .c-card-resource__body {
 	@include var(background-color, card-background);
 	margin-right: 1.25rem;
-	margin-left: 1.5rem;
+	margin-left: $ml-3;
 	padding: 1.5rem 2rem;
-	transition:
-		$animation-duration-shorter $animation-easing-character background-color,
+	transition: $animation-duration-shorter $animation-easing-character
+			background-color,
 		$animation-duration-shorter $animation-easing-character border-color,
 		$animation-duration-shorter $animation-easing-character color;
 
@@ -31,7 +31,6 @@
 	}
 }
 
-
 .c-card-resource__title {
 	@include var(color, card-heading-text);
 	letter-spacing: $font-tracking-tight;
@@ -47,12 +46,10 @@
 	}
 }
 
-
 .c-card-resource__meta {
 	@include var(color, card-meta-text);
 	line-height: $line-height-tight;
 }
-
 
 .c-card-resource__description {
 	max-width: $global-type-measure;

--- a/src/css/components/_c-card.scss
+++ b/src/css/components/_c-card.scss
@@ -2,6 +2,6 @@ $_card-inset: 1.5rem;
 $_card-outline: $border-thinner solid;
 
 .c-card__wrapper {
-	margin-bottom: 3rem;
+	margin-bottom: $mb-6;
 	max-width: $global-type-measure * 1.1;
 }

--- a/src/css/components/_c-changelog.scss
+++ b/src/css/components/_c-changelog.scss
@@ -1,10 +1,9 @@
 .c-changelog__version {
 	@include var(background-color, tag-background);
 	border-radius: 0.25rem;
-	margin-right: 0.5rem;
+	margin-right: $mr-1;
 	padding: 0.25rem 0.5rem;
 }
-
 
 .c-changelog__date {
 	@include var(color, text-accent);

--- a/src/css/components/_c-checklist.scss
+++ b/src/css/components/_c-checklist.scss
@@ -2,27 +2,25 @@
 
 $_checklist-checkbox-size: (
 	small: 1.25rem,
-	large: 1.5rem
+	large: 1.5rem,
 );
 $_checklist-icon-size: (
 	small: 1rem,
-	large: 1.5rem
+	large: 1.5rem,
 );
 $_checklist-inset: (
 	small: 3rem,
-	large: 4rem
+	large: 4rem,
 );
 $_checklist-padding: (
 	small: 1rem,
-	large: 1.5rem
+	large: 1.5rem,
 );
 
-
 .c-checklist__outer-wrapper {
-	margin-bottom: 3rem;
+	margin-bottom: $mb-6;
 	max-width: $global-type-measure * 1.1;
 }
-
 
 .c-checklist__wrapper {
 	// Supports
@@ -32,12 +30,10 @@ $_checklist-padding: (
 	}
 }
 
-
 .c-card__wrapper .c-checklist__wrapper:first-of-type .c-checklist {
 	border-top: $border-thinnest solid;
 	@include var(border-top-color, checklist-accent);
 }
-
 
 .c-checklist {
 	border-bottom: $border-thinnest solid;
@@ -85,14 +81,16 @@ $_checklist-padding: (
 	}
 }
 
-
 .c-checklist__summary {
 	cursor: pointer;
-	padding: map-get($_checklist-padding, small) map-get($_checklist-padding, small) map-get($_checklist-padding, small) 1rem;
+	padding: map-get($_checklist-padding, small)
+		map-get($_checklist-padding, small) map-get($_checklist-padding, small) 1rem;
 
 	// Breakpoints
 	@include mappy-bp(palm-medium) {
-		padding: map-get($_checklist-padding, large) map-get($_checklist-padding, large) map-get($_checklist-padding, large) 1.5rem;
+		padding: map-get($_checklist-padding, large)
+			map-get($_checklist-padding, large) map-get($_checklist-padding, large)
+			1.5rem;
 	}
 
 	// States
@@ -127,11 +125,11 @@ $_checklist-padding: (
 		flex-shrink: 0;
 	}
 
-		// Breakpoints
-		@include mappy-bp(palm-medium) {
-			height: map-get($_checklist-icon-size, large);
-			width: map-get($_checklist-icon-size, large);
-		}
+	// Breakpoints
+	@include mappy-bp(palm-medium) {
+		height: map-get($_checklist-icon-size, large);
+		width: map-get($_checklist-icon-size, large);
+	}
 
 	// User Queries
 	@media screen and (prefers-reduced-motion: reduce) {
@@ -139,15 +137,13 @@ $_checklist-padding: (
 	}
 }
 
-
 .c-checklist__title {
-margin-left: 1rem;
+	margin-left: $ml-2;
 	// Supports
 	@supports #{$supports-flex} {
 		flex: 1;
 	}
 }
-
 
 .c-checklist__checkbox {
 	// Supports
@@ -159,7 +155,7 @@ margin-left: 1rem;
 
 	input[type="checkbox"] {
 		position: relative;
-			left: 0.2rem; // HACK: Ensures iOS checkboxes are tucked fully under the generated checkbox
+		left: 0.2rem; // HACK: Ensures iOS checkboxes are tucked fully under the generated checkbox
 	}
 
 	// SEE: https://adrianroselli.com/2017/05/under-engineered-custom-radio-buttons-and-checkboxen.html
@@ -175,7 +171,10 @@ margin-left: 1rem;
 		float: left;
 		height: map-get($_checklist-checkbox-size, small);
 		margin-right: math.div(map-get($_checklist-checkbox-size, small), 1.5);
-		margin-left: math.div(map-get($_checklist-checkbox-size, small), -2); // This covers the native checkbox element
+		margin-left: math.div(
+			map-get($_checklist-checkbox-size, small),
+			-2
+		); // This covers the native checkbox element
 		position: relative;
 		width: map-get($_checklist-checkbox-size, small);
 
@@ -183,7 +182,10 @@ margin-left: 1rem;
 		@include mappy-bp(palm-medium) {
 			height: map-get($_checklist-checkbox-size, large);
 			margin-right: math.div(map-get($_checklist-checkbox-size, large), 1.5);
-			margin-left: math.div(map-get($_checklist-checkbox-size, large), -2); // This covers the native checkbox element
+			margin-left: math.div(
+				map-get($_checklist-checkbox-size, large),
+				-2
+			); // This covers the native checkbox element
 			width: map-get($_checklist-checkbox-size, large);
 		}
 	}
@@ -200,8 +202,8 @@ margin-left: 1rem;
 		display: block;
 		height: map-get($_checklist-checkbox-size, small);
 		position: relative;
-			top: 0.5em;
-			left: 0.5em;
+		top: 0.5em;
+		left: 0.5em;
 		transform: rotate(0deg);
 		width: map-get($_checklist-checkbox-size, small);
 
@@ -232,9 +234,8 @@ margin-left: 1rem;
 	}
 }
 
-
 .c-checklist__citation {
-	margin-top: 0.5rem;
+	margin-top: $mt-1;
 	padding-left: map-get($_checklist-inset, small);
 
 	// Breakpoints
@@ -242,7 +243,6 @@ margin-left: 1rem;
 		padding-left: map-get($_checklist-inset, large);
 	}
 }
-
 
 .c-checklist__link {
 	@include link-states(checklist-accent);
@@ -258,7 +258,6 @@ margin-left: 1rem;
 		text-decoration: none;
 	}
 }
-
 
 .c-checklist__description {
 	line-height: $line-height-looser;

--- a/src/css/components/_c-divider.scss
+++ b/src/css/components/_c-divider.scss
@@ -1,6 +1,6 @@
 .c-divider {
 	border: $border-thin solid;
 	@include var(border-color, divider-background);
-	margin-top: 3rem;
-	margin-bottom: 3rem;
+	margin-top: $mt-6;
+	margin-bottom: $mb-6;
 }

--- a/src/css/components/_c-dos-donts.scss
+++ b/src/css/components/_c-dos-donts.scss
@@ -1,5 +1,5 @@
 .c-dos-donts {
-	margin-top: 1.5rem;
+	margin-top: $mt-3;
 
 	// Text-level formatting
 	p {
@@ -18,7 +18,7 @@
 	}
 
 	p:first-of-type {
-		margin-top: 0.5rem;
+		margin-top: $mt-1;
 	}
 
 	p:nth-child(odd) {

--- a/src/css/components/_c-featured.scss
+++ b/src/css/components/_c-featured.scss
@@ -9,13 +9,13 @@
 
 .c-featured__body {
 	margin-right: 0;
-	margin-bottom: 2rem;
-	margin-left: 1.5rem;
+	margin-bottom: $mb-4;
+	margin-left: $ml-3;
 	padding: 1.5rem 2rem;
 	@include var(background-color, featured-card-background);
 	@include var(color, featured-card-text);
-	transition:
-		$animation-duration-shorter $animation-easing-character background-color,
+	transition: $animation-duration-shorter $animation-easing-character
+			background-color,
 		$animation-duration-shorter $animation-easing-character border-color,
 		$animation-duration-shorter $animation-easing-character color;
 
@@ -27,7 +27,6 @@
 		}
 	}
 }
-
 
 .c-featured__title {
 	letter-spacing: $font-tracking-tight;
@@ -44,11 +43,9 @@
 	}
 }
 
-
 .c-featured__meta {
 	line-height: $line-height-tight;
 }
-
 
 .c-featured__description {
 	max-width: $global-type-measure;

--- a/src/css/components/_c-footer.scss
+++ b/src/css/components/_c-footer.scss
@@ -2,9 +2,8 @@
 	font-family: $font-family-secondary;
 }
 
-
 .c-footer__subnav {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 
 	// Supports
 	@supports #{$supports-flex} {
@@ -19,7 +18,7 @@
 
 		@include mappy-bp(lap-small) {
 			width: initial;
-			margin-right: 2rem;
+			margin-right: $mr-4;
 		}
 
 		@include mappy-bp(lap-medium) {
@@ -28,24 +27,21 @@
 	}
 }
 
-
 .c-footer__heading {
 	padding-left: 0.5ch;
 }
 
-
 .c-footer__list {
 	@include preserve-list-semantics();
 
-	margin-top: 1rem;
+	margin-top: $mt-2;
 	margin-left: 0.4rem;
 
 	// Text-level formatting
 	li {
-		margin-top: 0.5rem;
+		margin-top: $mt-1;
 	}
 }
-
 
 .c-footer__link {
 	@include link-states(footer-link-text);
@@ -59,18 +55,17 @@
 	}
 }
 
-
 .c-footer__tagline {
 	@include var(color, footer-tagline-text);
 	font-family: $font-family-primary;
 	font-size: $font-size-heading-small;
 	line-height: $line-height-single;
-	margin-top: 2rem;
+	margin-top: $mt-4;
 
 	// Breakpoints
 	@include mappy-bp(palm-small) {
 		font-size: $font-size-body-medium;
-		margin-top: 0;
+		margin-top: $mt-0;
 	}
 
 	@include mappy-bp(lap-small) {
@@ -78,7 +73,6 @@
 		margin-top: 3.5rem;
 	}
 }
-
 
 .c-footer__copyright-link {
 	@include link-states(footer-link-text);

--- a/src/css/components/_c-form.scss
+++ b/src/css/components/_c-form.scss
@@ -1,10 +1,8 @@
 $_c-input-margin-top: 1.5rem;
 
-
 .c-form {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 }
-
 
 .c-form__label {
 	display: inline-block;
@@ -13,15 +11,15 @@ $_c-input-margin-top: 1.5rem;
 	padding-bottom: 0.25rem;
 }
 
-
 .c-form__input {
 	@include var(background-color, body-background);
 	@include var(color, body-text);
 	border: $border-thinnest solid;
 	@include var(border-color, input-border);
 	line-height: $line-height-single;
-	padding: 0.5rem;
-	transition: background-color $animation-duration-shorter $animation-easing-character;
+	padding: $p-1;
+	transition: background-color $animation-duration-shorter
+		$animation-easing-character;
 	width: 100%;
 
 	&:hover,
@@ -45,12 +43,10 @@ $_c-input-margin-top: 1.5rem;
 	}
 }
 
-
 .c-form__input--multiline {
 	line-height: $line-height-loose;
 	min-height: 15rem;
 }
-
 
 .c-form__button {
 	@include var(background-color, button-background);
@@ -63,7 +59,8 @@ $_c-input-margin-top: 1.5rem;
 	min-width: 20ch;
 	padding: 0.75rem 1.25rem;
 	text-transform: uppercase;
-	transition: background-color $animation-duration-shorter $animation-easing-character;
+	transition: background-color $animation-duration-shorter
+		$animation-easing-character;
 
 	// States
 	&:hover {
@@ -72,8 +69,7 @@ $_c-input-margin-top: 1.5rem;
 
 	&:focus {
 		@include var(background-color, button-focus-background);
-		box-shadow:
-			0 0 0 em(2) var(--color-body-background),
+		box-shadow: 0 0 0 em(2) var(--color-body-background),
 			0 0 0 em(4) var(--color-button-background);
 		outline: $border-thin solid transparent;
 	}
@@ -88,7 +84,6 @@ $_c-input-margin-top: 1.5rem;
 	}
 }
 
-
 .c-form__vendor {
 	@include link-states(body-text);
 
@@ -98,17 +93,15 @@ $_c-input-margin-top: 1.5rem;
 	}
 }
 
-
 .c-form__instructions {
 	position: relative;
-		bottom: 1rem;
+	bottom: 1rem;
 }
-
 
 .c-form__error-wrapper {
 	border: $border-thin solid;
 	@include var(border-color, error);
-	padding: 0.5rem;
+	padding: $p-1;
 
 	.c-form__error-list {
 		padding: 0 1rem;
@@ -120,7 +113,7 @@ $_c-input-margin-top: 1.5rem;
 	}
 }
 
-.c-form__input[aria-invalid]{
+.c-form__input[aria-invalid] {
 	border: $border-thinner solid;
 	@include var(border-color, error);
 }
@@ -128,7 +121,7 @@ $_c-input-margin-top: 1.5rem;
 .c-form__progress {
 	@include var(background-color, progress-background);
 	min-height: 2rem;
-	margin-bottom: 3rem;
+	margin-bottom: $mb-6;
 	max-width: 68ch;
 
 	// Supports
@@ -139,19 +132,16 @@ $_c-input-margin-top: 1.5rem;
 	}
 }
 
-
 .c-form__progress-fill {
 	@include var(background-color, progress-bar);
 }
 
-
 .c-form__progress-label {
 	@include var(background-color, body-background);
 	font-family: $font-family-secondary;
-	margin-top: 0;
+	margin-top: $mt-0;
 	padding-left: 1rem;
 }
-
 
 .c-form__legal {
 	margin-top: 0.25rem !important;

--- a/src/css/components/_c-homepage-card.scss
+++ b/src/css/components/_c-homepage-card.scss
@@ -9,11 +9,9 @@
 	}
 }
 
-
 .c-homepage-card--resources {
-	margin-right: 2rem;
+	margin-right: $mr-4;
 }
-
 
 .c-homepage-card--spotlight {
 	// Breakpoints
@@ -23,14 +21,12 @@
 
 	// Supports
 	@supports #{$supports-flex} {
-
 		// Breakpoints
 		@include mappy-bp(palm-large) {
 			justify-self: end;
 		}
 	}
 }
-
 
 .c-homepage-card__image-link {
 	// States
@@ -39,21 +35,18 @@
 	}
 }
 
-
 .c-homepage-card__image {
 	cursor: pointer;
-	margin-top: 3rem;
+	margin-top: $mt-6;
 	filter: var(--image-filter);
 }
-
 
 .c-homepage-card__author {
 	@include var(color, card-heading-text);
 	font-family: $font-family-secondary;
 	letter-spacing: $font-tracking-slight;
-	margin-top: 1.5rem;
+	margin-top: $mt-3;
 }
-
 
 .c-homepage-card__title {
 	cursor: pointer;
@@ -61,11 +54,10 @@
 	text-decoration: none;
 }
 
-
 .c-homepage-card__description {
 	font-family: $font-family-secondary;
-	margin-top: 1rem;
-	margin-bottom: 1rem;
+	margin-top: $mt-2;
+	margin-bottom: $mb-2;
 	max-width: 50ch;
 }
 
@@ -74,7 +66,7 @@
 	@include var(border-color, secondary-link-accent);
 	@include var(color, secondary-link-text);
 	font-family: $font-family-secondary;
-	margin-top: 1rem;
+	margin-top: $mt-2;
 	text-decoration: none;
 
 	// States
@@ -102,7 +94,6 @@
 	}
 }
 
-
 .c-homepage-card__checklist {
 	height: auto;
 	position: relative;
@@ -120,12 +111,10 @@
 	}
 }
 
-
 .c-homepage-card__spotlight-avatar {
 	@include avatar-size("large");
 	position: relative;
 }
-
 
 .c-homepage-card__spotlight__info {
 	@include var(background-color, featured-card-background);
@@ -144,11 +133,9 @@
 	}
 }
 
-
 .c-homepage-card__spotlight-name {
 	font-family: $font-family-secondary;
 }
-
 
 .c-homepage-card__spotlight-role {
 	@include var(color, featured-card-heading-text);

--- a/src/css/components/_c-homepage-feature.scss
+++ b/src/css/components/_c-homepage-feature.scss
@@ -4,7 +4,7 @@
 .c-homepage-feature {
 	// Contexts
 	&:not(:first-of-type) {
-		margin-top: 6rem;
+		margin-top: $mt-12;
 	}
 
 	// Supports
@@ -13,7 +13,6 @@
 		gap: 1.5rem;
 	}
 }
-
 
 .c-homepage-feature--50-50 {
 	// Supports
@@ -26,7 +25,6 @@
 		}
 	}
 }
-
 
 .c-homepage-feature--60-40 {
 	// Supports

--- a/src/css/components/_c-linkroll.scss
+++ b/src/css/components/_c-linkroll.scss
@@ -2,17 +2,16 @@
 //
 // Style guide: Components.linkroll
 .c-linkroll {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 }
-
 
 .c-linkroll__link {
 	border-left: $border-thicker solid;
 	@include var(border-color, linkroll-gray);
 	padding: 1.25rem 1.75rem;
 	text-decoration: none;
-	transition:
-		background-color $animation-duration-shorter $animation-easing-character,
+	transition: background-color $animation-duration-shorter
+			$animation-easing-character,
 		color $animation-duration-shorter $animation-easing-character;
 
 	// States
@@ -81,12 +80,10 @@
 	}
 }
 
-
 .c-linkroll__link--featured {
 	border-top: $border-thicker solid transparent;
 	border-left: none;
 }
-
 
 .c-linkroll__entry {
 	@include preserve-list-semantics();
@@ -94,23 +91,19 @@
 	margin-top: 1.25rem;
 }
 
-
 .c-linkroll__category {
 	@include var(color, card-meta-text);
 }
 
-
 .c-linkroll__category--featured {
 	padding-top: 1rem;
 }
-
 
 .c-linkroll__title {
 	@include var(color, card-text);
 	line-height: $line-height-tight;
 	text-decoration: none;
 }
-
 
 .c-linkroll__featured {
 	border-bottom: $border-thin dotted transparent;

--- a/src/css/components/_c-logo.scss
+++ b/src/css/components/_c-logo.scss
@@ -46,7 +46,6 @@
 	}
 }
 
-
 .c-logo__lockup {
 	// Supports
 	@supports #{$supports-flex} {
@@ -55,7 +54,6 @@
 		flex-direction: row;
 	}
 }
-
 
 .c-logo__icon {
 	fill: $color-white;
@@ -67,9 +65,8 @@
 	}
 }
 
-
 .c-logo__wordmark {
 	fill: $color-white;
 	margin-top: 0.25rem;
-	margin-left: 0.5rem;
+	margin-left: $ml-1;
 }

--- a/src/css/components/_c-person.scss
+++ b/src/css/components/_c-person.scss
@@ -1,13 +1,13 @@
 $_person-distance: (
 	small: 6rem,
-	large: 14rem
+	large: 14rem,
 );
 
 .c-person {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 
 	&:first-of-type {
-		margin-top: 0;
+		margin-top: $mt-0;
 	}
 }
 
@@ -50,7 +50,7 @@ $_person-distance: (
 		@include avatar-size("medium");
 
 		left: initial;
-		margin-left: 1rem;
+		margin-left: $ml-2;
 		right: initial;
 	}
 
@@ -71,16 +71,16 @@ $_person-distance: (
 	}
 }
 
-
 .c-person__info {
 	border: $border-thinnest solid;
 	@include var(border-color, card-outline);
 	@include var(background-color, card-background);
-	margin-top: 4rem;
+	margin-top: $mt-8;
 	min-height: 10rem;
 	padding: 1.5rem;
 	max-width: $global-type-measure;
-	transition: $animation-duration-shorter $animation-easing-character background-color;
+	transition: $animation-duration-shorter $animation-easing-character
+		background-color;
 
 	// Breakpoints
 	@include mappy-bp(palm-small) {
@@ -106,7 +106,6 @@ $_person-distance: (
 	}
 }
 
-
 .c-person__link {
 	@include link-states(card-heading-text);
 	font-family: $font-family-secondary;
@@ -124,14 +123,12 @@ $_person-distance: (
 	}
 }
 
-
 .c-person__spotlight-link {
 	@include link-states(card-heading-text);
 
 	display: inline-block;
-	margin-top: 1rem;
+	margin-top: $mt-2;
 }
-
 
 .c-person__name {
 	font-family: $font-family-secondary;
@@ -150,9 +147,8 @@ $_person-distance: (
 	}
 }
 
-
 .c-person__biography {
 	font-family: $font-family-secondary;
-	margin-top: 1rem;
+	margin-top: $mt-2;
 	max-width: $global-type-measure;
 }

--- a/src/css/components/_c-post-collection.scss
+++ b/src/css/components/_c-post-collection.scss
@@ -2,49 +2,45 @@
 	border-top: $border-thicker solid currentColor;
 	@include var(background-color, post-rec-background);
 	@include var(color, post-rec-accent);
-  counter-reset: post-collection;
-  padding: 1rem 2rem;
+	counter-reset: post-collection;
+	padding: 1rem 2rem;
 	max-width: 68ex;
 }
 
-
 .c-post-collection__title {
 	border-bottom: $border-thin dotted currentColor;
-  margin-top: 0;
+	margin-top: $mt-0;
 	padding-bottom: 1rem;
 }
 
-
 .c-post-collection__list {
-  margin-top: 1rem;
-  list-style-type: none;
+	margin-top: $mt-2;
+	list-style-type: none;
 }
-
 
 .c-post-collection__item {
 	@include var(color, post-rec-text);
-  position: relative;
-  margin-top: 0.5rem;
-  counter-increment: post-collection;
-  font-family: $font-family-secondary;
+	position: relative;
+	margin-top: $mt-1;
+	counter-increment: post-collection;
+	font-family: $font-family-secondary;
 
-  &::before {
-    content: "Part " counter(post-collection) ": ";
-    text-transform: uppercase;
-  }
+	&::before {
+		content: "Part " counter(post-collection) ": ";
+		text-transform: uppercase;
+	}
 }
-
 
 .c-post-collection__link {
 	@include link-states(post-rec-accent, post-rec-focus-text);
 
 	// States
-  &[aria-current] {
-    text-decoration: none;
-    color: currentColor;
+	&[aria-current] {
+		text-decoration: none;
+		color: currentColor;
 
 		&:focus {
 			@include var(color, post-rec-focus-text);
 		}
-  }
+	}
 }

--- a/src/css/components/_c-post.scss
+++ b/src/css/components/_c-post.scss
@@ -1,7 +1,6 @@
 $_c-post-breathing-room: 6ex;
 $_c-post-vertical-spacing: 4ex;
 
-
 // Post
 //
 // A post component contains all content and information used for The A11Y
@@ -60,7 +59,6 @@ $_c-post-vertical-spacing: 4ex;
 	}
 }
 
-
 .c-post__category__link {
 	@include link-states(rte-accent);
 	text-decoration: none;
@@ -71,12 +69,12 @@ $_c-post-vertical-spacing: 4ex;
 	}
 }
 
-
 .c-post__title {
 	@include var(color, heading-text);
 	font-size: $font-size-heading-small;
 	line-height: $line-height-tight;
-	margin: 0.75rem map-get($global-post-content-inset, small) 2rem map-get($global-post-content-inset, small);
+	margin: 0.75rem map-get($global-post-content-inset, small) 2rem
+		map-get($global-post-content-inset, small);
 	padding-right: 1rem;
 
 	// Breakpoints
@@ -98,12 +96,11 @@ $_c-post-vertical-spacing: 4ex;
 		}
 
 		@include mappy-bp(lap-medium) {
-			margin-top: 0;
+			margin-top: $mt-0;
 			margin-left: map-get($global-post-content-inset, small);
 		}
 	}
 }
-
 
 .c-post__metadata {
 	border-top: $border-thinnest solid;
@@ -139,20 +136,18 @@ $_c-post-vertical-spacing: 4ex;
 	}
 }
 
-
 .c-post__metadata--author,
 .c-post__metadata--published,
 .c-post__metadata--updated {
 	display: block;
 }
 
-
 .c-post__metadata--author {
-	margin-bottom: 0.5rem;
+	margin-bottom: $mb-1;
 
 	// Breakpoints
 	@include mappy-bp(lap-small) {
-		margin-bottom: 0;
+		margin-bottom: $mb-0;
 	}
 
 	// Supports
@@ -162,11 +157,10 @@ $_c-post-vertical-spacing: 4ex;
 		// Breakpoints
 		@include mappy-bp(lap-small) {
 			flex-grow: 4;
-			margin-bottom: 0;
+			margin-bottom: $mb-0;
 		}
 	}
 }
-
 
 .c-post__metadata--published,
 .c-post__metadata--updated {
@@ -176,17 +170,15 @@ $_c-post-vertical-spacing: 4ex;
 
 		// Breakpokints
 		@include mappy-bp(lap-small) {
-			margin-left: 0.5rem;
+			margin-left: $ml-1;
 		}
 	}
 }
-
 
 .c-post__metadata-link {
 	@include link-states(heading-text);
 	text-underline-offset: 0.2em;
 }
-
 
 .c-post__list-item {
 	// Supports
@@ -194,7 +186,6 @@ $_c-post-vertical-spacing: 4ex;
 		flex-grow: 1;
 	}
 }
-
 
 .c-content {
 	line-height: $line-height-double;

--- a/src/css/components/_c-preface.scss
+++ b/src/css/components/_c-preface.scss
@@ -1,7 +1,7 @@
 .c-preface {
 	@include var(color, text-accent);
-	margin-top: 0.5rem;
-	margin-bottom: 2rem;
+	margin-top: $mt-1;
+	margin-bottom: $mb-4;
 	margin-left: $_card-inset;
 	max-width: $global-type-measure;
 }

--- a/src/css/components/_c-primary-nav.scss
+++ b/src/css/components/_c-primary-nav.scss
@@ -5,35 +5,33 @@
 	@include var(background-color, nav-background);
 }
 
-
 .c-primary-nav__list {
 	@include preserve-list-semantics();
 }
 
-
 .c-primary-nav__list-item {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 	text-align: center;
 
 	// Supports
 	@supports #{$supports-flex} {
-		margin-top: 1rem;
+		margin-top: $mt-2;
 		margin-left: 0;
 		width: 33%;
 
 		// Breakpoints
 		@include mappy-bp(palm-small) {
-			margin-right: 0.5rem;
+			margin-right: $mr-1;
 			width: initial;
 			flex-grow: 1;
 		}
 
 		@include mappy-bp(palm-medium) {
-			margin-right: 1rem;
+			margin-right: $mr-2;
 		}
 
 		@include mappy-bp(lap-small) {
-			margin-top: 0;
+			margin-top: $mt-0;
 		}
 	}
 
@@ -63,14 +61,14 @@
 	}
 }
 
-
 .c-primary-nav__link {
 	border-bottom: $border-thinner solid transparent;
 	@include var(color, nav-link-text);
 	font-family: $font-family-secondary;
 	padding: 0.25rem 0.5rem;
 	text-decoration: none;
-	transition: $animation-duration-short $animation-easing-character border-bottom-color;
+	transition: $animation-duration-short $animation-easing-character
+		border-bottom-color;
 
 	// States
 	&:hover {

--- a/src/css/components/_c-recommended-reading.scss
+++ b/src/css/components/_c-recommended-reading.scss
@@ -15,7 +15,6 @@
 	}
 }
 
-
 .c-recommended-reading__wrapper {
 	// Supports
 	@supports #{$supports-flex} {
@@ -25,7 +24,6 @@
 	}
 }
 
-
 .c-recommended-reading__link {
 	border-top: $border-thicker solid currentColor;
 	@include var(background-color, post-rec-background);
@@ -33,8 +31,8 @@
 	line-height: $line-height-tight;
 	padding: 1rem;
 	text-decoration: none;
-	transition:
-		background-color $animation-duration-shorter $animation-easing-character,
+	transition: background-color $animation-duration-shorter
+			$animation-easing-character,
 		color $animation-duration-shorter $animation-easing-character;
 
 	// States
@@ -63,19 +61,17 @@
 	}
 }
 
-
 .c-recommended-reading__category {
 	border-bottom: $border-thin dotted currentColor;
 	display: block;
 	padding-bottom: 0.75rem;
 }
 
-
 .c-recommended-reading__title {
 	@include var(color, post-rec-text);
 	display: block;
 	font-size: $font-size-body-tiny;
-	margin-top: 1rem;
+	margin-top: $mt-2;
 
 	// Breakpoints
 	@include mappy-bp(palm-small) {

--- a/src/css/components/_c-simple.scss
+++ b/src/css/components/_c-simple.scss
@@ -12,9 +12,7 @@
 		object-fit: contain;
 		@include var(color, hero-background-text);
 	}
-
 }
-
 
 .c-simple__hero {
 	position: relative;
@@ -22,13 +20,13 @@
 	@include var(background-color, hero-content-background);
 	@include var(border-color, hero-content-accent);
 	@include var(color, hero-content-text);
-	margin-top: 2rem;
+	margin-top: $mt-4;
 	padding: 1rem 2rem 2rem;
 	z-index: 1;
 
 	// Supports
 	@supports #{$supports-flex} {
-		margin-top: 0;
+		margin-top: $mt-0;
 
 		// Breakpoints
 		@include mappy-bp(palm-large) {
@@ -43,10 +41,9 @@
 	// Text-level formatting
 	p {
 		font-family: $font-family-secondary;
-		margin-top: 1.5rem;
+		margin-top: $mt-3;
 	}
 }
-
 
 .c-simple__link {
 	@include link-states(link-text);

--- a/src/css/components/_c-sponsors.scss
+++ b/src/css/components/_c-sponsors.scss
@@ -2,14 +2,13 @@
 	@include var(background-color, sponsors-background);
 }
 
-
 .c-sponsor__link {
 	width: $global-sponsor-width;
-	margin-bottom: 1rem;
+	margin-bottom: $mb-2;
 	@include var(color, body-text);
 
 	&:last-of-type {
-		margin-bottom: 0;
+		margin-bottom: $mb-0;
 	}
 
 	// States
@@ -21,11 +20,10 @@
 	@supports #{$supports-grid} {
 		// Breakpoints
 		@include mappy-bp(palm-medium) {
-			margin-bottom: 0;
+			margin-bottom: $mb-0;
 		}
 	}
 }
-
 
 .c-sponsor__ad {
 	filter: var(--image-filter);

--- a/src/css/components/_c-spotlight.scss
+++ b/src/css/components/_c-spotlight.scss
@@ -1,4 +1,3 @@
-
 .c-spotlight__hero-avatar {
 	@include avatar-size("hero");
 
@@ -7,7 +6,7 @@
 		// Breakpoints
 		@include mappy-bp(lap-small) {
 			margin-left: auto;
-			margin-right: 3rem;
+			margin-right: $mr-6;
 		}
 	}
 
@@ -16,7 +15,6 @@
 		-ms-high-contrast-adjust: none;
 	}
 }
-
 
 .c-spotlight__subheading {
 	@include var(color, text-accent);

--- a/src/css/components/_c-theme-switcher.scss
+++ b/src/css/components/_c-theme-switcher.scss
@@ -1,26 +1,22 @@
 .c-theme-switcher {
 	border: none;
-	margin: 0;
-	padding: 0;
+	margin: $m-0;
+	padding: $p-0;
 }
-
 
 .c-theme-switcher__wrapper {
 	display: flex;
 	flex-direction: row;
 }
 
-
 .c-theme-switcher__title {
 	display: inline;
 	padding-right: 1rem;
 }
 
-
 .c-theme-switcher__input {
 	@include var(accent-color, input-accent);
 }
-
 
 .c-theme-switcher__label {
 	margin-right: 0.75rem;

--- a/src/css/components/_c-wcag-explanation.scss
+++ b/src/css/components/_c-wcag-explanation.scss
@@ -1,7 +1,7 @@
 .c-wcag-explanation {
 	@include var(background-color, featured-card-background);
 	font-family: $font-family-secondary;
-	margin-bottom: 1rem;
+	margin-bottom: $mb-2;
 	padding: 0.5rem 1.5rem 2rem;
 
 	// Breakpoints
@@ -11,19 +11,18 @@
 
 	// Text-level formatting
 	p {
-		margin-top: 1.5rem;
+		margin-top: $mt-3;
 		max-width: $global-type-measure;
 	}
 }
 
-
 .c-wcag-explanation__compliance-level {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 	max-width: $global-type-measure;
 
 	// Breakpoints
 	@include mappy-bp(palm-large) {
-		margin-top: 0.5rem;
+		margin-top: $mt-1;
 
 		// Supports
 		@supports #{$supports-flex} {
@@ -33,12 +32,11 @@
 			// This knocks it back into position.
 			&:last-of-type {
 				position: relative;
-					right: 1rem;
+				right: 1rem;
 			}
 		}
 	}
 }
-
 
 .c-wcag-explanation__icon {
 	width: 65%;
@@ -52,13 +50,12 @@
 	@include mappy-bp(palm-large) {
 		// Supports
 		@supports #{$supports-flex} {
-			margin-top: 2rem;
-			margin-right: 1.5rem;
+			margin-top: $mt-4;
+			margin-right: $mr-3;
 			width: rem(320);
 		}
 	}
 }
-
 
 .c-wcag-explanation__conformance-level {
 	display: block;
@@ -66,6 +63,6 @@
 
 	// Breakpoints
 	@include mappy-bp(palm-large) {
-		margin-top: 0;
+		margin-top: $mt-0;
 	}
 }

--- a/src/css/components/content/_cms.scss
+++ b/src/css/components/content/_cms.scss
@@ -29,12 +29,12 @@
 	}
 
 	.footnotes-list {
-		margin-top: 1rem;
+		margin-top: $mt-2;
 	}
 
 	.footnote-item {
 		p {
-			margin-top: 0;
+			margin-top: $mt-0;
 		}
 	}
 

--- a/src/css/components/content/_inline-content.scss
+++ b/src/css/components/content/_inline-content.scss
@@ -20,12 +20,10 @@
 		}
 	}
 
-
 	kbd {
 		margin-left: 0.25ch;
 		margin-right: 0.25ch;
 	}
-
 
 	// Blockquote
 	//
@@ -39,7 +37,7 @@
 		padding: 1.5rem 1rem;
 
 		p:first-of-type {
-			margin-bottom: 0;
+			margin-bottom: $mb-0;
 		}
 
 		// Breakpoints
@@ -86,7 +84,6 @@
 		}
 	}
 
-
 	// Preformatted Text
 	//
 	// Style guide: Components.post.pre
@@ -116,7 +113,6 @@
 
 		margin-top: 4ex;
 	}
-
 
 	// Table
 	//

--- a/src/css/components/content/_lists.scss
+++ b/src/css/components/content/_lists.scss
@@ -36,19 +36,18 @@
 				font-size: 3ex;
 				height: 1rem;
 				position: relative;
-					top: rem(9);
-					right: 1.75rem;
+				top: rem(9);
+				right: 1.75rem;
 				width: 1rem;
 			}
 		}
 
 		ol {
-			margin-top: 0;
-			margin-left: 2rem;
-			margin-bottom: 1rem;
+			margin-top: $mt-0;
+			margin-left: $ml-4;
+			margin-bottom: $mb-2;
 		}
 	}
-
 
 	// Unordered List
 	//
@@ -71,18 +70,17 @@
 				font-size: 2ex;
 				height: 1rem;
 				position: relative;
-					top: rem(20);
-					right: rem(36);
+				top: rem(20);
+				right: rem(36);
 				width: 1rem;
 			}
 
 			ul {
-				margin-top: 0;
-				margin-left: 2rem;
+				margin-top: $mt-0;
+				margin-left: $ml-4;
 			}
 		}
 	}
-
 
 	// Definition List
 	//
@@ -92,7 +90,7 @@
 
 		dt {
 			font-weight: $font-weight-bold;
-			margin-top: 1.5rem;
+			margin-top: $mt-3;
 			margin-left: map-get($global-post-content-inset, small) * -1;
 		}
 
@@ -101,7 +99,6 @@
 		}
 	}
 }
-
 
 .c-further-reading__source {
 	display: block;

--- a/src/css/components/content/_spacing.scss
+++ b/src/css/components/content/_spacing.scss
@@ -35,7 +35,7 @@
 
 	.template-collection & {
 		p:first-of-type {
-			margin-top: 0;
+			margin-top: $mt-0;
 		}
 	}
 
@@ -51,7 +51,7 @@
 				font-size: 1.25rem;
 				font-family: $font-family-secondary;
 				line-height: $line-height-looser;
-				margin-top: 0;
+				margin-top: $mt-0;
 				margin-bottom: $_c-post-vertical-spacing * 1.25;
 				@include post-content-flourish(169, 0.75rem);
 			}

--- a/src/css/layout/_l-footer.scss
+++ b/src/css/layout/_l-footer.scss
@@ -8,13 +8,12 @@
 	}
 }
 
-
 // [1] Adds and removes the tagline from the footer nav lockup by toggling
 // its presence in the DOM. Nested CSS grids won't zoom properly and cause text
 // to not break, so we need to use this approach.
 .l-footer__meta--footer {
 	display: initial;
-	margin-top: 3rem;
+	margin-top: $mt-6;
 
 	// Breakpoints
 	@include mappy-bp(palm-small) {
@@ -22,14 +21,13 @@
 	}
 
 	@include mappy-bp(lap-small) {
-		margin-top: 6rem;
+		margin-top: $mt-12;
 	}
 
 	@include mappy-bp(lap-small) {
 		display: unset;
 	}
 }
-
 
 .l-footer__meta--nav {
 	@include hide(remove); // [1]
@@ -48,11 +46,9 @@
 	}
 }
 
-
 .l-footer__theme-switcher {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 }
-
 
 .l-footer__tagline-copyright {
 	// Supports
@@ -64,26 +60,24 @@
 		@include mappy-bp(lap-small) {
 			flex-direction: row;
 			justify-content: space-between;
-			margin-top: 1rem;
+			margin-top: $mt-2;
 		}
 	}
 }
 
-
 .l-footer__copyright {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 	// Supports
 	@supports #{$supports-flex} {
 		// Breakpoints
 		@include mappy-bp(lap-small) {
-			margin-top: 0;
+			margin-top: $mt-0;
 		}
 	}
 }
 
-
 .l-footer__top {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 
 	// Breakpoints
 	@include mappy-bp(palm-small) {
@@ -91,6 +85,6 @@
 	}
 
 	@include mappy-bp(lap-small) {
-		margin-top: 0;
+		margin-top: $mt-0;
 	}
 }

--- a/src/css/layout/_l-generic-title.scss
+++ b/src/css/layout/_l-generic-title.scss
@@ -1,5 +1,5 @@
 .l-generic-title {
-background-color: #ffc2cc;
+	background-color: #ffc2cc;
 	// Supports
 	@supports #{$supports-flex} {
 		// Breakpoints
@@ -29,12 +29,11 @@ background-color: #ffc2cc;
 	}
 }
 
-
 .l-hero__promo {
 	margin-left: map-get($global-bleed, small);
 	margin-right: map-get($global-bleed, small);
 	position: relative;
-		top: 50%;
+	top: 50%;
 	transform: perspective(1px) translateY(-60%); // HACK: Keeps`perspective(1px)` keeps content from rendering blurry
 
 	// Supports
@@ -63,8 +62,8 @@ background-color: #ffc2cc;
 
 		// Breakpoints
 		@include mappy-bp(palm-large) {
-			margin-top: 0;
-			margin-bottom: 0;
+			margin-top: $mt-0;
+			margin-bottom: $mb-0;
 			position: unset;
 			transform: none;
 		}

--- a/src/css/layout/_l-hero.scss
+++ b/src/css/layout/_l-hero.scss
@@ -1,7 +1,8 @@
 .l-hero {
 	position: relative;
 	height: auto;
-	padding: map-get($global-bleed, small) 0 (map-get($global-bleed, large) * 1.5) 0;
+	padding: map-get($global-bleed, small) 0 (map-get($global-bleed, large) * 1.5)
+		0;
 
 	@include mappy-bp(lap-large) {
 		height: 75vh;
@@ -39,7 +40,6 @@
 	}
 }
 
-
 .l-hero__promo {
 	margin-left: map-get($global-bleed, small);
 	margin-right: map-get($global-bleed, small);
@@ -74,14 +74,14 @@
 
 		// Breakpoints
 		@include mappy-bp(palm-large) {
-			margin-top: 0;
-			margin-bottom: 0;
+			margin-top: $mt-0;
+			margin-bottom: $mb-0;
 			position: unset;
 			transform: none;
 		}
 
 		@include mappy-bp(lap-small) {
-			margin: 0;
+			margin: $m-0;
 		}
 
 		@include mappy-bp(lap-large) {

--- a/src/css/layout/_l-post.scss
+++ b/src/css/layout/_l-post.scss
@@ -1,11 +1,10 @@
 .l-post {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 
 	// Breakpoints
 	@include mappy-bp(lap-medium) {
-		margin-top: 4rem;
+		margin-top: $mt-8;
 	}
-
 
 	&--collection {
 		.l-post__header,
@@ -20,14 +19,18 @@
 	}
 }
 
-
 .l-post__header {
 	// Breakpoints
 	@include mappy-bp(lap-medium) {
 		// Supports
 		@supports #{$supports-grid} {
 			display: grid;
-			grid-template-columns: map-get($global-post-columns, category) map-get($global-post-columns, gutter) 2fr 2rem map-get($global-post-columns, toc);
+			grid-template-columns:
+				map-get($global-post-columns, category) map-get(
+					$global-post-columns,
+					gutter
+				)
+				2fr 2rem map-get($global-post-columns, toc);
 			grid-template-rows: auto auto;
 			grid-template-areas:
 				"category . title    . ."
@@ -35,7 +38,6 @@
 		}
 	}
 }
-
 
 .l-post__body {
 	margin-top: 6ex;
@@ -45,13 +47,17 @@
 		// Supports
 		@supports #{$supports-grid} {
 			display: grid;
-			grid-template-columns: map-get($global-post-columns, category) map-get($global-post-columns, gutter) 2fr 2rem map-get($global-post-columns, toc);
+			grid-template-columns:
+				map-get($global-post-columns, category) map-get(
+					$global-post-columns,
+					gutter
+				)
+				2fr 2rem map-get($global-post-columns, toc);
 			grid-template-rows: auto auto;
 			grid-template-areas: ". . content     . toc";
 		}
 	}
 }
-
 
 .l-post__category {
 	// Supports
@@ -60,7 +66,6 @@
 	}
 }
 
-
 .l-post__title {
 	// Supports
 	@supports #{$supports-grid} {
@@ -68,14 +73,12 @@
 	}
 }
 
-
 .l-post__metadata {
 	// Supports
 	@supports #{$supports-grid} {
 		grid-area: metadata;
 	}
 }
-
 
 .l-post__content {
 	@include post-content-inset("small");
@@ -102,11 +105,10 @@
 		}
 
 		@include mappy-bp(lap-small) {
-			margin-top: 0;
+			margin-top: $mt-0;
 		}
 	}
 }
-
 
 .l-post__linkroll {
 	// Supports

--- a/src/css/layout/_l-primary-nav.scss
+++ b/src/css/layout/_l-primary-nav.scss
@@ -20,16 +20,15 @@
 	}
 }
 
-
 .l-primary-nav__sections {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 	width: 100%;
 
 	// Supports
 	@supports #{$supports-flex} {
 		display: flex;
 		flex-flow: row wrap;
-		margin-top: 0;
+		margin-top: $mt-0;
 
 		// Breakpoints
 		@include mappy-bp(palm-small) {

--- a/src/css/layout/_l-toc.scss
+++ b/src/css/layout/_l-toc.scss
@@ -18,57 +18,57 @@
 			margin-top: 17.5rem;
 
 			.l-toc {
-				margin-top: 0; // BUG: .v-toc is getting regenerated on some pages
-				margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+				margin-top: $mt-0; // BUG: .v-toc is getting regenerated on some pages
+				margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 			}
 		}
 	}
 
 	.template-checklist & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-resources & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-about & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-contribute & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-team & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-authors & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-spotlight & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
 	.template-posts & {
 		.l-toc {
-			margin-left: 1.5rem; // BUG: .v-toc is getting regenerated on some pages
+			margin-left: $ml-3; // BUG: .v-toc is getting regenerated on some pages
 		}
 	}
 
@@ -78,7 +78,7 @@
 		// Breakpoints
 		@include mappy-bp(palm-medium) {
 			margin-right: map-get($global-post-content-inset, "medium");
-			margin-bottom: 2rem;
+			margin-bottom: $mb-4;
 			margin-left: map-get($global-post-content-inset, "medium") * 0.5;
 		}
 

--- a/src/css/logic/_mixins.headings.scss
+++ b/src/css/logic/_mixins.headings.scss
@@ -4,7 +4,6 @@
 //
 // Styleguide Logic.Mixins.Headings
 
-
 // heading-largest
 //
 // Weight: 4
@@ -16,14 +15,13 @@
 @mixin heading-largest() {
 	font-size: 3rem;
 	line-height: $line-height-single;
-	margin-bottom: 1rem;
+	margin-bottom: $mb-2;
 
 	// Breakpoints
 	@include mappy-bp(lap-small) {
 		font-size: 3.5rem;
 	}
 }
-
 
 // heading-large
 //

--- a/src/css/logic/_mixins.hide.scss
+++ b/src/css/logic/_mixins.hide.scss
@@ -13,7 +13,7 @@
 		height: 1px;
 		margin: -1px;
 		overflow: hidden;
-		padding: 0;
+		padding: $p-0;
 		position: absolute;
 		white-space: nowrap;
 		width: 1px;
@@ -22,7 +22,7 @@
 		&:focus {
 			clip: auto;
 			height: auto;
-			margin: 0;
+			margin: $m-0;
 			overflow: visible;
 			position: static;
 			width: auto;

--- a/src/css/logic/_mixins.lede.scss
+++ b/src/css/logic/_mixins.lede.scss
@@ -9,5 +9,5 @@
 @mixin lede() {
 	font-size: 1.15rem;
 	line-height: $line-height-double;
-	margin-top: 0;
+	margin-top: $mt-0;
 }

--- a/src/css/utilities/_spacing.scss
+++ b/src/css/utilities/_spacing.scss
@@ -31,7 +31,7 @@
 }
 
 .u-spacing-top-shorter {
-	margin-top: 0.5rem;
+	margin-top: $mt-1;
 }
 
 .u-spacing-top-short {
@@ -39,28 +39,27 @@
 }
 
 .u-spacing-top-medium {
-	margin-top: 1rem;
+	margin-top: $mt-2;
 }
 
 .u-spacing-top-long {
-	margin-top: 1.5rem;
+	margin-top: $mt-3;
 }
 
 .u-spacing-top-longer {
-	margin-top: 2rem;
+	margin-top: $mt-4;
 }
 
 .u-spacing-top-longest {
-	margin-top: 3rem;
+	margin-top: $mt-6;
 }
-
 
 .u-spacing-right-shortest {
 	margin-right: 0.25rem;
 }
 
 .u-spacing-right-shorter {
-	margin-right: 0.5rem;
+	margin-right: $mr-1;
 }
 
 .u-spacing-right-short {
@@ -68,28 +67,27 @@
 }
 
 .u-spacing-right-medium {
-	margin-right: 1rem;
+	margin-right: $mr-2;
 }
 
 .u-spacing-right-long {
-	margin-right: 1.5rem;
+	margin-right: $mr-3;
 }
 
 .u-spacing-right-longer {
-	margin-right: 2rem;
+	margin-right: $mr-4;
 }
 
 .u-spacing-right-longest {
-	margin-right: 3rem;
+	margin-right: $mr-6;
 }
-
 
 .u-spacing-bottom-shortest {
 	margin-bottom: 0.25rem;
 }
 
 .u-spacing-bottom-shorter {
-	margin-bottom: 0.5rem;
+	margin-bottom: $mb-1;
 }
 
 .u-spacing-bottom-short {
@@ -97,7 +95,7 @@
 }
 
 .u-spacing-bottom-medium {
-	margin-bottom: 1rem;
+	margin-bottom: $mb-2;
 }
 
 .u-spacing-bottom-long {
@@ -105,20 +103,19 @@
 }
 
 .u-spacing-bottom-longer {
-	margin-bottom: 2rem;
+	margin-bottom: $mb-4;
 }
 
 .u-spacing-bottom-longest {
-	margin-bottom: 3rem;
+	margin-bottom: $mb-6;
 }
-
 
 .u-spacing-left-shortest {
 	margin-left: 0.25rem;
 }
 
 .u-spacing-left-shorter {
-	margin-left: 0.5rem;
+	margin-left: $ml-1;
 }
 
 .u-spacing-left-short {
@@ -126,18 +123,17 @@
 }
 
 .u-spacing-left-medium {
-	margin-left: 1rem;
+	margin-left: $ml-2;
 }
 
 .u-spacing-left-long {
-	margin-left: 1.5rem;
+	margin-left: $ml-3;
 }
 
 .u-spacing-left-longer {
-	margin-left: 2rem;
+	margin-left: $ml-4;
 }
 
 .u-spacing-left-longest {
 	margin-left: 3rem;
 }
-

--- a/src/css/utilities/_variables.scss
+++ b/src/css/utilities/_variables.scss
@@ -1,0 +1,55 @@
+// Variables
+
+// Declaration of common measurements for margin and padding
+
+//$m-0:0rem
+//$m-1:0.5rem
+//$m-2:1rem
+//$m-3:1.5rem
+//$m-4:2rem
+//$m-5:2.5rem
+//$m-6:3rem
+//$m-7:3.5rem
+//$m-8:4rem
+//$m-9:4.5rem
+//$m-10:5rem
+//$m-11:5.5rem
+//$m-12:6rem
+
+
+// margin
+$m-0: margin: 0;
+
+// margin-top
+$mt-0: margin-top: 0;
+$mt-1: margin-top: 0.5rem;
+$mt-2: margin-top: 1rem;
+$mt-3: margin-top: 1.5rem;
+$mt-4: margin-top: 2rem;
+$mt-6: margin-top: 3rem;
+$mt-8: margin-top: 4rem;
+$mt-12: margin-top: 6rem;
+
+// margin-right
+$mr-1: margin-right: 0.5rem;
+$mr-2: margin-right: 1rem;
+$mr-3: margin-right: 1.5rem;
+$mr-4: margin-right: 2rem;
+$mr-6: margin-right: 3rem;
+
+// margin-bottom
+$mb-0: margin-bottom: 0;
+$mb-1: margin-bottom: 0.5rem;
+$mb-2: margin-bottom: 1rem;
+$mb-4: margin-bottom: 2rem;
+$mb-6: margin-bottom: 3rem;
+
+// margin-left
+$ml-1: margin-left: 0.5rem;
+$ml-2: margin-left: 1rem;
+$ml-3: margin-left: 1.5rem;
+$ml-4: margin-left: 2rem;
+
+// padding
+$p-0: padding: 0;
+$p-1: padding: 0.5rem;

--- a/src/css/vendor/_v-toc.scss
+++ b/src/css/vendor/_v-toc.scss
@@ -1,7 +1,7 @@
 // tableOfContents.js
 // http://github.com/cferdinandi/table-of-contents
 .v-toc {
-	margin-right: 2rem;
+	margin-right: $mr-4;
 	position: relative;
 	z-index: z(component);
 
@@ -60,11 +60,10 @@
 	width: 1rem;
 }
 
-
 .v-toc__title {
 	display: block;
 	font-weight: 700;
-	margin-left: 0.5rem;
+	margin-left: $ml-1;
 	/* stylelint-disable-next-line property-no-unknown */
 	text-decoration-thickness: $border-thinnest;
 	text-underline-offset: 0.5em;
@@ -74,7 +73,6 @@
 		text-decoration: none;
 	}
 }
-
 
 .v-toc__nav {
 	padding: 0 1rem 1.55rem 0;
@@ -90,7 +88,7 @@
 		padding-top: none;
 		list-style-type: none;
 
-	ol {
+		ol {
 			padding-left: 1rem;
 		}
 	}
@@ -104,7 +102,7 @@
 
 		// Supports
 		@supports #{$supports-flex} {
-			margin-bottom: 0;
+			margin-bottom: $mb-0;
 		}
 
 		code {
@@ -119,11 +117,11 @@
 			text-transform: none;
 
 			&:first-of-type {
-				margin-top: 1rem;
+				margin-top: $mt-2;
 
 				// Supports
 				@supports #{$supports-flex} {
-					margin-top: 0;
+					margin-top: $mt-0;
 				}
 			}
 
@@ -142,8 +140,7 @@
 	a[href] {
 		@include var(color, toc-link-text);
 		text-decoration: none;
-		transition:
-			$animation-duration-short $animation-easing-character color,
+		transition: $animation-duration-short $animation-easing-character color,
 			$animation-duration-short $animation-easing-character border;
 
 		// Supports


### PR DESCRIPTION
Hello! 

We have tried to fix the issue #934 as part of an Open Source Event in Madrid. We have incorporated all repeated measurements in variables. The variables were created according to this table:

Declaration of common measurements for margin and padding
$m-0: 0rem
$m-1: 0.5rem
$m-2: 1rem
$m-3: 1.5rem
$m-4: 2rem
$m-5: 2.5rem
$m-6: 3rem
$m-7: 3.5rem
$m-8: 4rem
$m-9: 4.5rem
$m-10: 5rem
$m-11: 5.5rem
$m-12: 6rem

Then we created $m- for margin $mt- for margin-top, $mr- for margin-right, $mb- for margin-bottom and $ml- for margin-left. Also, $p- for padding and the rest according to this logic.

We hope to hear from you soon and collaborate more with you in the future.


