### PR TITLE
Removes conference dates from the resource listing

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -754,7 +754,6 @@
 		{
 			"title": "axe-con Digital Accessibility Conference",
 			"description": "Axe-con is an open and inclusive digital accessibility conference that welcomes developers, designers, business users, and accessibility professionals of all experience levels to a new kind of accessibility conference focused on building, testing, and maintaining accessible digital experiences.",
-			"additional": "March 15–16",
 			"url": "https://www.deque.com/axe-con/"
 		},
 		{


### PR DESCRIPTION
To maintain consistency with the rest of the conference and meetups in our resource listing, I am removing the dates from the conferences. We have the links pointing to the actual conference/meetup which should give the visitors of the website the required information about the dates of the conference (which is a better source-of-truth for the conference dates).