### PR TITLE
update six broken links, five in the /posts directory and one in /_data

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -607,7 +607,7 @@
 			"title": "Colorable",
 			"description": "Color palette combination contrast tester",
 			"additional": "Brent Jackson",
-			"url": "https://jxnblk.github.io/colorable/demos/text/"
+			"url": "https://colorable.jxnblk.com/"
 		},
 		{
 			"title": "Color Safe",

--- a/src/posts/getting-started-with-orca.md
+++ b/src/posts/getting-started-with-orca.md
@@ -19,7 +19,7 @@ tags:
 
 Orca is a free, open-source screen reader developed under the [GNOME project](https://www.gnome.org/about-us/). Several Linux distributions have it installed by default.
 
-This article will introduce you to the basics of Orca on Gnome desktop environment on [Ubuntu](https://help.ubuntu.com/lts/installation-guide/s390x/ch01s01.html) version 20.04 LTS. There might be some slight variations if you are using a different desktop environment or using GNOME on a different Linux distribution. You need to consult the manual for your Linux distribution or desktop environment.
+This article will introduce you to the basics of Orca on Gnome desktop environment on [Ubuntu](https://help.ubuntu.com/20.04/installation-guide/s390x/index.html) version 20.04 LTS. There might be some slight variations if you are using a different desktop environment or using GNOME on a different Linux distribution. You need to consult the manual for your Linux distribution or desktop environment.
 
 ## Launching Orca
 

--- a/src/posts/how-to-write-accessible-forms.md
+++ b/src/posts/how-to-write-accessible-forms.md
@@ -123,7 +123,7 @@ In the code below, there is an empty [live region](https://developer.mozilla.org
 If validation errors occur, two things happen:
 
 1. The [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) is populated upon form submission, announcing to assistive devices that there are errors.
-2. Each invalid `<input>` is given an [`aria-invalid="true"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) attribute and connected to a __hint__ using  an [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attribute.
+2. Each invalid `<input>` is given an [`aria-invalid="true"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) attribute and connected to a __hint__ using  an [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute.
 
 Here's the markup for the email field in its invalid state:
 

--- a/src/posts/should-i-use-an-accessibility-overlay.md
+++ b/src/posts/should-i-use-an-accessibility-overlay.md
@@ -153,7 +153,7 @@ further_reading:
     url: https://blindjournalist.wordpress.com/2021/03/04/why-i-blocked-accessibe/
     source: Robert Kingett
   - title: "Why should you stay away from Accessibility Overlays?"
-    url: https://www.barrierbreak.com/2021/07/13/why-should-you-stay-away-from-accessibility-overlays/
+    url: https://www.barrierbreak.com/why-should-you-stay-away-from-accessibility-overlays/
     source: Barrier Break
 tags:
   - background

--- a/src/posts/text-resizing-in-ios-and-android.md
+++ b/src/posts/text-resizing-in-ios-and-android.md
@@ -32,7 +32,7 @@ If you manually limit how large your text scales it may cause issues for people 
 
 You can use a [tool called the Android Emulator](https://developer.android.com/studio/run/emulator) to preview how your app works in the context of different android devices. This can help you stay aware of how people who use different types of androids experience your app.
 
-Again, users can only zoom in on specified areas, so you'll need to use [scale-independent pixels](https://www.pixel-ruler.net/android-scale-independent-pixel) to determine the size of your text.
+Again, users can only zoom in on specified areas, so you'll need to use [scale-independent pixels](https://web.archive.org/web/20160507221349/https://www.pixel-ruler.net/android-scale-independent-pixel) to determine the size of your text.
 
 There isn't a tool like Dynamic Type in Android, so you'll need to scale the text at different sizes yourself. Material design [has a resource](https://material.io/design/typography/the-type-system.html#type-scale) that makes a good starting point.
 


### PR DESCRIPTION
* Updated `"Why should you stay away from Accessibility Overlays?"` in `/posts/should-i-use-an-accessibility-overlay.md` to: https://www.barrierbreak.com/why-should-you-stay-away-from-accessibility-overlays/ 

* Updated `aria-invalid` link in `/posts/how-to-write-accessible-forms.md` to:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid

* Updated `aria-describedby` link in `/posts/how-to-write-accessible-forms.md` to: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid

* Updated `Ubuntu 20.04 "Focal Fossa" Installation Guide` in `/posts/getting-started-with-orca.md` to: https://help.ubuntu.com/20.04/installation-guide/s390x/index.html

* Updated `"scale-independent pixels"` in `/posts/text-resizing-in-ios-and-android.md` to: https://web.archive.org/web/20160507221349/https://www.pixel-ruler.net/android-scale-independent-pixel  (note: original website is no longer online, replaced with web archive link)

* Updated `Colorable` link in `/_data/resources.json` to: https://colorable.jxnblk.com/
