### PR TITLE
Remove broken link to Invision in sponsors.json

### DIFF
--- a/src/_data/sponsors.json
+++ b/src/_data/sponsors.json
@@ -1,11 +1,6 @@
 {
 	"sponsor": [
 		{
-			"image": "invision-design-forward-fund.svg",
-			"url": "https://www.invisionapp.com/design-forward-fund",
-			"alt": "InVision Design Forward Fund. Apply now."
-		},
-		{
 			"image": "go-make-things.svg",
 			"url": "https://gomakethings.com/",
 			"alt": "Go make things. Learn Vanilla JavaScript. Get daily developer tips."


### PR DESCRIPTION
Invision has shutdown, so this link is broken.