### PR TITLE
logic and styling to expand and open checklist sections

### DIFF
--- a/src/checklist.njk
+++ b/src/checklist.njk
@@ -84,7 +84,11 @@ templateClass: template-checklist
 
 	<hr class="c-divider" />
 	
-	<button type="button" id="toggle-all" class="c-checklist-toggle" aria-expanded="false">Open All</button>
+	<button 
+		type="button" 
+		id="toggle-all" 
+		class="c-checklist-toggle c-checklist-toggle--global" 
+		aria-expanded="false">Open All</button>
 
 	{% for category, content in checklists %}
 	{# 6 May 2021: We don't publish our guidelines about SVGs #}
@@ -98,7 +102,10 @@ templateClass: template-checklist
 		{{ content.preface | safe }}
 	</p>
 
-	 <button type="button" class="c-checklist-toggle toggle-category"  aria-expanded="false">Open {{ category }}</button>
+	<button 
+		type="button" 
+		class="c-checklist-toggle c-checklist-toggle--category toggle-category" 
+		aria-expanded="false">Open {{ category }}</button>
 	
 	<div class="c-card__wrapper">
 		{% set tasks = content.tasks %}

--- a/src/checklist.njk
+++ b/src/checklist.njk
@@ -83,6 +83,8 @@ templateClass: template-checklist
 	</div>
 
 	<hr class="c-divider" />
+	
+	<button type="button" id="toggle-all" class="c-checklist-toggle" aria-expanded="false">Open All</button>
 
 	{% for category, content in checklists %}
 	{# 6 May 2021: We don't publish our guidelines about SVGs #}
@@ -95,6 +97,9 @@ templateClass: template-checklist
 	<p class="c-preface">
 		{{ content.preface | safe }}
 	</p>
+
+	 <button type="button" class="c-checklist-toggle toggle-category"  aria-expanded="false">Open {{ category }}</button>
+	
 	<div class="c-card__wrapper">
 		{% set tasks = content.tasks %}
 		{% for task in tasks %}

--- a/src/css/components/_c-checklist.scss
+++ b/src/css/components/_c-checklist.scss
@@ -290,3 +290,37 @@ margin-left: 1rem;
 		padding-left: map-get($_checklist-inset, large);
 	}
 }
+.c-checklist-toggle {
+    @include var(background-color, checklist-accent);
+    @include var(color, body-background);
+    border: none;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    font-family: $font-family-secondary;
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    transition: opacity $animation-duration-shorter $animation-easing-character;
+
+    &:hover {
+        opacity: 0.9;
+    }
+
+    &:focus {
+        outline: $border-thin solid;
+        @include var(outline-color, checklist-focus-text);
+        outline-offset: 0.125rem;
+    }
+
+    // User Queries
+    @media screen and (prefers-reduced-motion: reduce) {
+        transition: none;
+    }
+}
+
+#toggle-all {
+    margin-bottom: 2rem;
+}
+
+.toggle-category {
+    margin-bottom: 1.5rem;
+}

--- a/src/css/components/_c-checklist.scss
+++ b/src/css/components/_c-checklist.scss
@@ -317,10 +317,10 @@ margin-left: 1rem;
     }
 }
 
-#toggle-all {
+.c-checklist-toggle--global {
     margin-bottom: 2rem;
 }
 
-.toggle-category {
+.c-checklist-toggle--category {
     margin-bottom: 1.5rem;
 }

--- a/src/js/checklist.js
+++ b/src/js/checklist.js
@@ -62,6 +62,66 @@ function processChecklist() {
 	populateChecklistFromLocalStorage(checkboxSelector);
 	processChecklistClick(checkboxSelector);
 }
+/**
+ * Toggles all details elements within a container to a specific state
+ * @param {HTMLElement} container - The container element
+ * @param {boolean} shouldExpand - Whether to expand or collapse
+ */
+function toggleDetails(container, shouldExpand) {
+    var details = container.querySelectorAll('details');
+    var length = details.length;
+    for (var i = 0; i < length; ++i) {
+        if (shouldExpand) {
+            details[i].setAttribute('open', '');
+        } else {
+            details[i].removeAttribute('open');
+        }
+    }
+}
+
+/**
+ * Sets up toggle functionality for category and global controls
+ */
+function setupToggles() {
+    var mainContent = document.querySelector('[data-content]');
+    var toggleAllBtn = document.getElementById('toggle-all');
+    var allExpanded = false;
+
+    // Setup global toggle
+    if (toggleAllBtn) {
+        toggleAllBtn.setAttribute('aria-expanded', 'false');
+        
+        toggleAllBtn.addEventListener('click', function() {
+            allExpanded = !allExpanded;
+            toggleDetails(mainContent, allExpanded);
+            toggleAllBtn.setAttribute('aria-expanded', allExpanded.toString());
+            toggleAllBtn.textContent = allExpanded ? 'Close All' : 'Open All';
+        });
+    }
+
+    // Setup category toggles
+    var categoryToggles = document.querySelectorAll('.toggle-category');
+    var length = categoryToggles.length;
+    for (var i = 0; i < length; ++i) {
+        var toggle = categoryToggles[i];
+        toggle.setAttribute('aria-expanded', 'false');
+        
+        toggle.addEventListener('click', function(event) {
+            var btn = event.currentTarget;
+            var categorySection = btn.closest('[data-checklist-category]');
+            var categoryName = categorySection.getAttribute('data-checklist-category');
+            var isExpanded = btn.getAttribute('aria-expanded') === 'true';
+            var newExpandedState = !isExpanded;
+            
+            toggleDetails(categorySection, newExpandedState);
+            btn.setAttribute('aria-expanded', newExpandedState.toString());
+            btn.textContent = newExpandedState ? 
+                'Close ' + categoryName : 
+                'Open ' + categoryName;
+        });
+    }
+}
 
 openLinkedCheckListItem();
 processChecklist();
+setupToggles();


### PR DESCRIPTION
Open all:

All checklist items convert to open state if pressed, regardless of their category or prior state.
If pressed again, checklist items revert to a closed state.

Open section:

If pressed, all checklist items in the relevant section convert to open state, regardless of their category or prior state.
If pressed again, checklist items update to a closed state.

![image](https://github.com/user-attachments/assets/4465c9d7-cc12-4918-8d1e-34a4596df9ab)
![image](https://github.com/user-attachments/assets/75a5d8fd-3bff-43c0-8795-d97cb5f16ad5)

Closes #940 

