### PR TITLE
Add automated broken link checker using Lychee

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,68 @@
+name: Check for Broken Links
+
+on:
+  schedule:
+    # Run on the first day of every month at 9 AM UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Check for broken links
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          # Check the built site
+          args: >
+            --verbose
+            --no-progress
+            --accept 200,204,206,301,302,307,308
+            --timeout 20
+            --max-retries 3
+            --user-agent "Mozilla/5.0 (compatible; lychee/0.13.0; +https://github.com/lycheeverse/lychee)"
+            --exclude-loopback
+            --exclude "^https://twitter\.com"
+            --exclude "^https://x\.com"
+            --exclude "^https://linkedin\.com"
+            --exclude "localhost"
+            --exclude "example\.com"
+            --exclude "^mailto:"
+            --exclude "^tel:"
+            --exclude "^javascript:"
+            --exclude-path "node_modules"
+            --exclude-path ".git"
+            _site
+          output: ./lychee-report.md
+          format: markdown
+          fail: false # Don't fail the action, just report
+
+      - name: Create or update issue
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Monthly Broken Links Report"
+          content-filepath: ./lychee-report.md
+          labels: |
+            bug
+            help wanted
+            content
+          assignees: |
+            ericwbailey
+            scottohara

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,28 @@
+# Lychee ignore file for broken link checking
+
+# Social media sites often block automated checkers
+https://twitter.com/*
+https://x.com/*
+https://linkedin.com/*
+https://www.linkedin.com/*
+https://facebook.com/*
+https://www.facebook.com/*
+
+# Authentication required
+https://github.com/*/edit/*
+https://github.com/*/new/*
+
+# Local development
+http://localhost*
+http://127.0.0.1*
+
+# Examples and documentation
+http://example.com/*
+https://example.com/*
+
+# These sites often give false positives
+https://www.amazon.com/*
+https://codepen.io/*
+
+# Temporary ignores for known issues
+# Add specific URLs here that are temporarily down but expected to return


### PR DESCRIPTION
# Add automated broken link checker using Lychee

## Description

This PR implements automated broken link checking as discussed in issue #1521. It uses Lychee, the tool recommended in the issue discussion.

## Implementation Details

### Files Added

1. **`.github/workflows/broken-links.yml`** - GitHub Action workflow that:
   - Runs monthly (1st of each month at 9 AM UTC)
   - Can be triggered manually via workflow_dispatch
   - Builds the site before checking links
   - Creates a single issue if broken links are found

2. **`.lycheeignore`** - Configuration file to reduce false positives by excluding:
   - Social media URLs (often block automated tools)
   - Authentication-required pages
   - Local development URLs
   - Known problematic domains

### How It Works

1. **Build First**: The workflow builds the site to check actual output, not source files
2. **Comprehensive Checking**: Checks both internal and external links
3. **Smart Retries**: Retries failed requests up to 3 times with 20-second timeout
4. **Single Issue**: Creates one consolidated issue instead of multiple notifications
5. **Appropriate Labels**: Adds `bug`, `help wanted`, and `content` labels

### Configuration Choices

Based on the discussion in #1521:
- ✅ Uses Lychee as suggested by @p2635
- ✅ Runs periodically (monthly) rather than on every commit
- ✅ Creates a single issue to avoid notification spam
- ✅ Includes common exclusions to reduce false positives

## Testing

The workflow can be tested immediately after merging by:
1. Going to Actions tab
2. Selecting "Check for Broken Links" workflow
3. Clicking "Run workflow"

## Questions for Review

1. **Frequency**: Currently set to monthly. Would you prefer a different schedule?
2. **Assignees**: Currently assigns @ericwbailey and @scottohara. Should this be changed?
3. **Exclusions**: Are there other domains that commonly give false positives?
4. **Issue Title**: Currently "Monthly Broken Links Report". Preference for different naming?

## Related Issue

Resolves #1521

## Additional Notes

- The action won't fail the workflow even if broken links are found (uses `fail: false`)
- The report is in markdown format for easy reading
- Future enhancements could include caching to speed up checks