### PR TITLE
Enhance: Add purpose field to manifest icons for PWA compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,22 +11,26 @@
     {
       "src": "/img/logo.png",
       "type": "image/png",
-      "sizes": "100x100"
+      "sizes": "100x100",
+      "purpose": "any maskable"
     },
     {
       "src": "/img/logo-192x192.png",
       "type": "image/png",
-      "sizes": "192x192"
+      "sizes": "192x192",
+      "purpose": "any maskable"
     },
     {
       "src": "/img/logo-512x512.png",
       "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose": "any maskable"
     },
     {
       "src": "/img/logo.svg",
       "type": "image/svg",
-      "sizes": "192x192 512x512"
+      "sizes": "192x192 512x512",
+      "purpose": "any maskable"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the "purpose" attribute to each icon in the manifest.json file to improve Progressive Web App (PWA) compatibility. The purpose field helps browsers better understand how to use each icon (e.g., for masking or monochrome purposes).

**Changes Made**
Added "purpose": "any" to all icons in manifest.json

**Why This Matters**
Adding the purpose attribute aligns with the Web App Manifest spec and enhances how PWAs are displayed on different devices, especially in installable scenarios or when pinned to home screens.