### PR TITLE
Fix: replace dead color contrast checker link with active tool

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -57,11 +57,6 @@
 			"url": "https://a11ywins.tumblr.com/"
 		},
 		{
-			"title": "Alicia Jarvis' Inclusive Design Blog",
-			"description": "Hi, I’m Alicia. I'm a diversity, equity and inclusion strategist, researcher, and culture consultant based in Toronto.",
-			"url": "https://www.alicia.design/writing"
-		},
-		{
 			"title": "Level Access Blog",
 			"description": "Find out what’s happening in the world of accessible design, Level Access’ team updates, and better practices for an accessible web.",
 			"url": "https://www.levelaccess.com/blog/"
@@ -196,12 +191,6 @@
 			"url": "https://link.springer.com/book/10.1007/978-1-4842-4881-2"
 		},
 		{
-			"title": "Apps For All: Coding Accessible Web Applications",
-			"description": "Web accessibility is quite a large topic — far too large to fit into a small book. So, what will this book cover? Though we shall encounter visual design challenges, deal with performance issues, and adopt progressive enhancement — all of which are accessibility concerns — the underlying theme of this book is about making the interactivity of web applications include keyboard and screen reader users.",
-			"additional": "Heydon Pickering",
-			"url": "https://shop.smashingmagazine.com/products/apps-for-all"
-		},
-		{
 			"title": "Appt Accessibility Handbook",
 			"description": "The Appt Foundation is working towards a world where everyone can use apps equally. To make this vision a reality, we have written a handbook. It helps you learn the basics of app accessibility in a straightforward way.",
 			"additional": "Jan Jaap de Groot and Paul van Workum",
@@ -310,12 +299,6 @@
 			"url": "https://www.penguinrandomhouse.com/books/617802/disability-visibility-by-alice-wong/"
 		},
 		{
-			"title": "Giving a damn about accessibility",
-			"description": "A candid and practical handbook for designers.",
-			"additional": "Sheri Byrne-Haber, CPACC.",
-			"url": "https://accessibility.uxdesign.cc/"
-		},
-		{
 			"title": "The Glossary of Accessibility Design",
 			"description": "A guide to navigating the crucial field of accessibility design with precision and clarity. This comprehensive dictionary comprises over 700 meticulously defined terms, offering a vital resource for designers, developers, policymakers, and anyone dedicated to creating inclusive digital experiences.",
 			"additional": "Vimal Gupta",
@@ -340,12 +323,6 @@
 			"url": "https://bookshop.org/books/inclusive-design-for-organisations-including-your-missing-20-by-embedding-web-and-mobile-accessibility/9781781333952"
 		},
 		{
-			"title": "Inclusion: Diversity, The New Workplace & The Will To Change",
-			"description": "The Inclusion Dividend provides a framework to tap the bottom line impact that results from an inclusive culture.",
-			"additional": "Jennifer Brown",
-			"url": "https://jenniferbrownspeaks.com/jbs-book-inclusion"
-		},
-		{
 			"title": "The Inclusion Dividend: Why Investing in Diversity and Inclusion Pays Off",
 			"description": "The Inclusion Dividend provides a framework to tap the bottom line impact that results from an inclusive culture.",
 			"additional": "Mason Donovan, Mark Kaplan",
@@ -356,12 +333,6 @@
 			"description": "Effective dialogue across different dimensions of diversity, such as race, gender, age, religion, or sexual orientation, fosters a sense of belonging and inclusion, which in turn leads to greater productivity, performance, and innovation.",
 			"additional": "Mary-Frances Winters",
 			"url": "https://www.amazon.com/Inclusive-Conversations-Fostering-Belonging-Differences/dp/152308880X/"
-		},
-		{
-			"title": "Inclusive Design Patterns",
-			"description": "Inclusive Design Handbook gets to the bottom of it all: accessibility myths and rules of thumbs, WAI-ARIA roles, content accessibility guidelines, landmark roles, keyboard and touch accessibility, accessible markup and interaction patterns, accessible forms and widgets, multimedia accessibility and inclusive prototyping.",
-			"additional": "Heydon Pickering",
-			"url": "https://shop.smashingmagazine.com/products/inclusive-design-patterns"
 		},
 		{
 			"title": "Living in Information: Responsible Design for Digital Places",
@@ -944,11 +915,6 @@
 			"url": "https://www.accessibility.legal/"
 		},
 		{
-			"title": "Future Date",
-			"description": "Future Date is a free, volunteer-led, virtual accessibility conference. Our goal is to expose our audience to the pioneering work and lived experiences of disability and accessibility leaders.",
-			"url": "https://afuturedate.herokuapp.com/"
-		},
-		{
 			"title": "Global Accessibility Awareness Day",
 			"description": "The purpose of GAAD is to get everyone talking, thinking and learning about digital access and inclusion, and the more than One Billion people with disabilities/impairments.",
 			"url": "https://globalaccessibilityawarenessday.org/"
@@ -1055,12 +1021,6 @@
 			"description": "The A11Y Collective is the e-learning platform for anyone who wants to learn more about web accessibility. The courses focus mostly on knowledge and skills that are valuable for web designers, developers, webmasters, product owners and web editors.",
 			"additional": "a11y-collective.com",
 			"url": "https://a11y-collective.com/"
-		},
-		{
-			"title": "Thinking about Digital Accessibility: From Ally to Advocate",
-			"description": "In this book, we explore what digital accessibility is, how it is integrated with common functional roles, such as content writer, user experience designer, or engineer, and how it grows as the knowledge and skill of an individual develops, answering the question “how do I get there from here”.",
-			"additional": "H. Robert King",
-			"url": "https://www.everand.com/book/527830515/Thinking-about-Digital-Accessibility-From-Ally-to-Advocate"
 		},
 		{
 			"title": "Web Accessibility by Google",
@@ -1447,12 +1407,6 @@
 			"url": "https://knowbility.org/blog/2019/an-alt-text-primer/"
 		},
 		{
-			"title": "Considerations when writing alt text",
-			"description": "Find out what alt text is, why it’s so important, and how to write content for your images.",
-			"additional": "Scott Vinkle",
-			"url": "https://ux.shopify.com/considerations-when-writing-alt-text-a9c1985a8204"
-		},
-		{
 			"title": "Creating Accessible SVGs",
 			"description": "Scalable Vector Graphics (SVGs) have been around since 1999, but they have seen a real resurgence in use as design interactions have become more complex and CSS/JavaScript have replaced antiquated animation programs such as Adobe Flash.",
 			"additional": "Deque",
@@ -1789,12 +1743,6 @@
 			"description": "Making sure that PDFs are accessible to everyone, including those using assistive technologies like screen readers, refreshable braille displays, screen magnifiers, etc., can be a daunting technical process. In this article, we’ll address two basic PDF accessibility concepts – tagging and reading order. Then, in subsequent articles, we’ll address more specific topics in PDF accessibility.",
 			"additional": "CommonLook",
 			"url": "https://commonlook.com/pdf-tagging-and-reading-order/"
-		},
-		{
-			"title": "PDF accessibility introduction",
-			"description": "Although web accessibility is most commonly thought of when talking about digital accessibility, document accessibility also plays an important role. Document formats such as Word, PowerPoint, Excel, ePub, and most commonly PDF, are quite common and are usually linked within web pages or sent via email. As such, it’s important to make sure that those documents are accessible as well.",
-			"additional": "Pragmatic Access",
-			"url": "https://pragmaticaccess.com/articles/2019-05-30-pdf-accessibility-introduction"
 		},
 		{
 			"title": "WebAIM: PDF Accessibility",
@@ -2231,13 +2179,6 @@
 			"type": "Talk"
 		},
 		{
-			"title": "Introduction to Web Accessibility",
-			"description": "This brief introductory video geared towards technology professionals provides a baseline understanding of the topic of Web and digital accessibility: designing, coding, and testing with users with disabilities in mind, including the diverse assistive technology and tools they may be using to engage with their computing devices.",
-			"additional": "Dr. Michele A. Williams",
-			"url": "https://mawconsultingllc.com/intro-to-web-accessibility/",
-			"type": "Talk"
-		},
-		{
 			"title": "JavaScript and Civil Rights (Marcy Sutton)",
 			"description": "Web Rebels (2017)",
 			"additional": "YouTube",
@@ -2517,12 +2458,6 @@
 			"description": "Every day we use graphic communication design from reading letters which have come through the post, or the newspaper in the morning, to reading and using information at work, to travelling and navigating in the environment. How can we include as many people as possible when designing graphic communication and information, and how do we not unnecessarily exclude people?",
 			"additional": "User Design, Illustration and Typesetting, previously Usability Geek",
 			"url": "https://medium.com/@user_design/information-on-different-types-of-people-for-graphic-communication-website-and-information-4b6454905bb1"
-		},
-		{
-			"title": "Accessibility for Teams",
-			"description": "A ‘quick-start’ guide for embedding accessibility and inclusive design practices into your team’s workflow.",
-			"additional": "U.S. General Services Administration",
-			"url": "https://accessibility.digital.gov/"
 		},
 		{
 			"title": "Access & Use",

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -785,10 +785,10 @@
 			"url": "https://colorandcontrast.com/"
 		},
 		{
-			"title": "Color Contrast Checker",
-			"description": "This tool tests the contrast of a background color and foreground color for accessibility.",
-			"additional": "Josef Eines",
-			"url": "https://www.alarmsystem.no/color-contrast/"
+			"title": "WCAG Color Contrast Checker",
+			"description": "Checks foreground and background color contrast against WCAG 2.1 AA and AAA standards, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a markdown bug report for logging accessibility defects.",
+			"additional": "David Mello",
+			"url": "https://davidmello.com/tools/color-contrast-checker"
 		},
 		{
 			"title": "Colorblind Web Page Filter",

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -785,12 +785,6 @@
 			"url": "https://colorandcontrast.com/"
 		},
 		{
-			"title": "WCAG Color Contrast Checker",
-			"description": "Checks foreground and background color contrast against WCAG 2.1 AA and AAA standards, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a markdown bug report for logging accessibility defects.",
-			"additional": "David Mello",
-			"url": "https://davidmello.com/tools/color-contrast-checker"
-		},
-		{
 			"title": "Colorblind Web Page Filter",
 			"description": "Use the Colorblind Colorlab to select safe colors earlier in the design process.",
 			"additional": "toptal",
@@ -825,6 +819,12 @@
 			"description": "Find good constrast for web accessibility between two colors.",
 			"additional": "Tanaguru",
 			"url": "http://contrast-finder.tanaguru.com/"
+		},
+		{
+			"title": "WCAG Color Contrast Checker",
+			"description": "Checks foreground and background color contrast against WCAG 2.1 AA and AAA standards, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a markdown bug report for logging accessibility defects.",
+			"additional": "David Mello",
+			"url": "https://davidmello.com/tools/color-contrast-checker"
 		},
 		{
 			"title": "We are Colorblind",

--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -795,7 +795,7 @@
 			"title": "WCAG Color Contrast Checker",
 			"description": "Checks foreground and background color contrast against WCAG 2.1 AA and AAA standards, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a markdown bug report for logging accessibility defects.",
 			"additional": "David Mello",
-			"url": "https://davidmello.com/tools/color-contrast-checker"
+			"url": "https://www.davidmello.com/tools/color-contrast-checker"
 		},
 		{
 			"title": "We are Colorblind",


### PR DESCRIPTION
## Summary

Removes a dead link to `https://www.alarmsystem.no/color-contrast/` which returns a 404. The domain (alarmsystem.no) is a parked domain, appears unrelated to accessibility tooling, and the entry looks like it may have been spam.

Replaced with [WCAG Color Contrast Checker](https://davidmello.com/tools/color-contrast-checker), an actively maintained tool that includes colorblindness simulation for four deficiency types (deuteranopia, protanopia, tritanopia, achromatopsia), accessible color variant suggestions, and a markdown bug report for logging accessibility defects.

## Changes

- `src/_data/resources.json` — replaced dead entry in the `colors` section with active tool

### Additional Dead Links Removed
| Status | URL |
|---|---|
| HTTP 404 | https://www.alicia.design/writing |
| HTTP 404 | https://shop.smashingmagazine.com/products/apps-for-all |
| HTTP 404 | https://jenniferbrownspeaks.com/jbs-book-inclusion |
| HTTP 404 | https://shop.smashingmagazine.com/products/inclusive-design-patterns |
| HTTP 404 | https://afuturedate.herokuapp.com/ |
| HTTP 404 | https://www.everand.com/book/527830515/Thinking-about-Digital-Accessibility-From-Ally-to-Advocate |
| HTTP 404 | https://ux.shopify.com/considerations-when-writing-alt-text-a9c1985a8204 |
| HTTP 404 | https://mawconsultingllc.com/intro-to-web-accessibility/ |
| DNS resolution failed | https://accessibility.uxdesign.cc/ |
| DNS resolution failed | https://pragmaticaccess.com/articles/2019-05-30-pdf-accessibility-introduction |
| DNS resolution failed | https://accessibility.digital.gov/ |

### Adding New Link

```json
{
  "title": "WCAG Color Contrast Checker",
  "description": "Checks foreground and background color contrast against WCAG 2.1 AA and AAA standards, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a markdown bug report for logging accessibility defects.",
  "additional": "David Mello",
  "url": "https://davidmello.com/tools/color-contrast-checker"
},
```

**Disclosure:** I am the author of the replacement tool being added in this PR.

## Why It Belongs Here
- Checks foreground/background color pairs against WCAG 2.1 AA and AAA contrast thresholds
- Colorblindness simulation for four deficiency types (deuteranopia, protanopia, tritanopia, achromatopsia)
- Accessible color variant suggestions when a pair fails
- Development team / Quality Assurance workflow features
  - Shareable URL via query params (`?fg=xxxxxx&bg=xxxxxx`) for sharing / explaining issues to coworkers
  - Markdown bug report for logging accessibility defects in issue trackers

## Checklist

- [x] Free / no paywall
- [x] No UTM codes or tracking parameters in URL
- [x] No accessibility overlay plugins
- [x] Not hosted on Medium
- [x] Content aligns with The A11Y Project's mission
- [x] Entry sorted alphabetically within the category