### PR TITLE
Add Kat ADA to Professional help resources

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -1974,8 +1974,13 @@
 			"url": "https://intopia.digital/"
 		},
 		{
+						"title": "Kat ADA",
+						"description": "Done-for-you accessibility remediation for Squarespace websites: a specialist makes real fixes in the site's source rather than installing an overlay, with a free automated scan to show where a site stands.",
+						"url": "https://katadaapp.com/"
+		},
+				{
 			"title": "Knowbility",
-			"description": "Knowbility is a nonprofit organization with the goal of improving technology access for millions of youth and adults with disabilities all over the world.",
+								"description": "Knowbility is a nonprofit organization with the goal of improving technology access for millions of youth and adults with disabilities all over the world.",
 			"url": "https://knowbility.org/"
 		},
 		{


### PR DESCRIPTION
Adds Kat ADA to the Professional help section (alphabetical, between Intopia and Knowbility). Kat ADA is a done-for-you accessibility remediation service for Squarespace websites: a human specialist makes real fixes in the site's source (alt text, accessible names, labels, structure, contrast) rather than installing an overlay. The linked site offers a free automated scan so owners can see where they stand before paying anything. Plain URL, no tracking parameters. Disclosure: I am the founder, submitting on our own behalf.